### PR TITLE
GDB Control Flow Debugging

### DIFF
--- a/NoHoPython/Compilation/CallStackReporting.cs
+++ b/NoHoPython/Compilation/CallStackReporting.cs
@@ -10,7 +10,7 @@ namespace NoHoPython.Compilation
     {
         public static readonly int StackLimit = 1000;
 
-        public static void EmitReporter(StringBuilder emitter)
+        public static void EmitReporter(StatementEmitter emitter)
         {
             emitter.AppendLine($"static const char* _nhp_call_stack_src_locs[{StackLimit}];");
             emitter.AppendLine($"static const char* _nhp_call_stack_src[{StackLimit}];");
@@ -43,53 +43,60 @@ namespace NoHoPython.Compilation
             emitter.AppendLine("}");
         }
 
-        public static void EmitReportCall(StringBuilder emitter, IAstElement errorReportedElement, int indent)
+        public static void EmitReportCall(StatementEmitter emitter, IAstElement errorReportedElement, int indent)
         {
-            if(indent != -1)
-                CodeBlock.CIndent(emitter, indent);
-            
+            CodeBlock.CIndent(emitter, indent);
+            EmitReportCall(emitter, errorReportedElement);
+            emitter.AppendLine();
+        }
+
+        public static void EmitReportCall(IEmitter emitter, IAstElement errorReportedElement)
+        {
             emitter.Append("_nhp_santize_call(");
             CharacterLiteral.EmitCString(emitter, errorReportedElement.SourceLocation.ToString(), false, true);
             emitter.Append(", ");
             errorReportedElement.EmitSrcAsCString(emitter);
-
-            if(indent == -1)
-                emitter.Append(");");
-            else
-                emitter.AppendLine(");");
+            emitter.Append(");");
         }
 
-        public static void EmitReportReturn(StringBuilder emitter, int indent)
-        {
-            if (indent == -1)
-                emitter.Append("--_nhp_stack_size;");
-            else
-            {
-                CodeBlock.CIndent(emitter, indent);
-                emitter.AppendLine("--_nhp_stack_size;");
-            }
-        }
-
-        public static void EmitErrorLoc(StringBuilder emitter, IAstElement errorReportedElement, int indent=0)
+        public static void EmitReportReturn(StatementEmitter emitter, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
+            EmitReportReturn(emitter);
+            emitter.AppendLine();
+        }
+
+        public static void EmitReportReturn(IEmitter emitter) => emitter.Append("--_nhp_stack_size;");
+
+        public static void EmitErrorLoc(StatementEmitter emitter, IAstElement errorReportedElement, int indent)
+        {
+            CodeBlock.CIndent(emitter, indent);
+            EmitErrorLoc(emitter, errorReportedElement);
+            emitter.AppendLine();
+        }
+
+        public static void EmitErrorLoc(IEmitter emitter, IAstElement errorReportedElement)
+        {
             emitter.Append("_nhp_set_errloc(");
             CharacterLiteral.EmitCString(emitter, errorReportedElement.SourceLocation.ToString(), false, true);
             emitter.Append(", ");
             errorReportedElement.EmitSrcAsCString(emitter);
-            emitter.AppendLine(");");
+            emitter.Append(");");
         }
 
-        public static void EmitErrorLoc(StringBuilder emitter, string locationSrc, string src, int indent=0)
+        public static void EmitErrorLoc(StatementEmitter emitter, string locationSrc, string src, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             emitter.AppendLine($"_nhp_set_errloc({locationSrc}, {src});");
         }
 
-        public static void EmitPrintStackTrace(StringBuilder emitter, int indent=0)
+        public static void EmitPrintStackTrace(StatementEmitter emitter, int indent=0)
         {
             CodeBlock.CIndent(emitter, indent);
-            emitter.AppendLine("_nhp_print_stack_trace();");
+            EmitPrintStackTrace(emitter);
+            emitter.AppendLine();
         }
+
+        public static void EmitPrintStackTrace(IEmitter emitter) => emitter.Append("_nhp_print_stack_trace();");
     }
 }

--- a/NoHoPython/Compilation/CallStackReporting.cs
+++ b/NoHoPython/Compilation/CallStackReporting.cs
@@ -90,7 +90,7 @@ namespace NoHoPython.Compilation
             emitter.AppendLine($"_nhp_set_errloc({locationSrc}, {src});");
         }
 
-        public static void EmitPrintStackTrace(StatementEmitter emitter, int indent=0)
+        public static void EmitPrintStackTrace(StatementEmitter emitter, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             EmitPrintStackTrace(emitter);

--- a/NoHoPython/Compilation/Emitters.cs
+++ b/NoHoPython/Compilation/Emitters.cs
@@ -1,0 +1,126 @@
+﻿using NoHoPython.Syntax;
+using NoHoPython.Typing;
+using System.Diagnostics;
+using System.Text;
+
+namespace NoHoPython.IntermediateRepresentation
+{
+    public interface IEmitter
+    {
+        public void Append(string str);
+        public void Append(char c);
+    }
+
+    public sealed class BufferedEmitter : IEmitter
+    {
+        public static string EmitBufferedValue(IRValue value, IRProgram irProgram, Dictionary<Typing.TypeParameter, IType> typeArgs, string responsibleDestroyer)
+        {
+            BufferedEmitter bufferedEmitter = new();
+            value.Emit(irProgram, bufferedEmitter, typeArgs, responsibleDestroyer);
+            return bufferedEmitter.ToString();
+        }
+
+        public static string EmittedBufferedMemorySafe(IRValue value, IRProgram irProgram, Dictionary<Typing.TypeParameter, IType> typeArgs)
+        {
+            BufferedEmitter bufferedEmitter = new();
+            IRValue.EmitMemorySafe(value, irProgram, bufferedEmitter, typeArgs);
+            return bufferedEmitter.ToString();
+        }
+
+        private StringBuilder builder;
+
+        public BufferedEmitter()
+        {
+            this.builder = new();
+        }
+
+        public void Append(string str)
+        {
+            Debug.Assert(!str.Contains('\n'));
+            builder.Append(str);
+        }
+
+        public void Append(char c)
+        {
+            Debug.Assert(c != '\n');
+            builder.Append(c);
+        }
+
+        public override string ToString() => builder.ToString();
+    }
+
+    public sealed class StatementEmitter : IEmitter, IDisposable
+    {
+        private StreamWriter writer;
+        private StringBuilder currentLineBuilder;
+        private IRProgram irProgram;
+
+        public SourceLocation? LastSourceLocation { get; set; }
+
+        public StatementEmitter(string outputPath, IRProgram irProgram)
+        {
+            this.irProgram = irProgram;
+
+            if (File.Exists(outputPath))
+                File.Delete(outputPath);
+
+            writer = new(new FileStream(outputPath, FileMode.OpenOrCreate, FileAccess.Write));
+            currentLineBuilder = new();
+        }
+
+        public void Append(string str)
+        {
+            Debug.Assert(!str.Contains('\n'));
+            currentLineBuilder.Append(str);
+        }
+
+        public void Append(char c)
+        {
+            Debug.Assert(c != '\n');
+            currentLineBuilder.Append(c);
+        }
+
+        public void AppendLine(string str)
+        {
+            currentLineBuilder.Append(str);
+            AppendLine();
+        }
+
+        public void AppendLine()
+        {
+            if (irProgram.EmitLineDirectives && LastSourceLocation.HasValue)
+            {
+                BufferedEmitter bufferedEmitter = new();
+                LastSourceLocation.Value.EmitLineDirective(bufferedEmitter);
+                writer.WriteLine(bufferedEmitter.ToString());
+            }
+
+            writer.WriteLine(currentLineBuilder.ToString());
+            currentLineBuilder.Clear();
+        }
+
+        #region disposing
+        private bool isDisposed = false;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (isDisposed) return;
+
+            if (disposing)
+            {
+                // free managed resources
+                writer.Close();
+                writer.Dispose();
+            }
+
+            isDisposed = true;
+        }
+        #endregion
+    }
+}

--- a/NoHoPython/Compilation/Errors.cs
+++ b/NoHoPython/Compilation/Errors.cs
@@ -39,11 +39,9 @@ namespace NoHoPython.IntermediateRepresentation
 
     public sealed class CannotEmitDestructorError : CodegenError
     {
-        public IRValue Value { get; private set; }
-
-        public CannotEmitDestructorError(IRValue value) : base(value, "Cannot emit destructor for value. Please move to a variable, or consider enabling expression-statements.")
+        public CannotEmitDestructorError(IRElement? errorReportedElement) : base(errorReportedElement, "Cannot emit destructor for value. Please move to a variable, or consider enabling expression-statements.")
         {
-            Value = value;
+
         }
     }
 

--- a/NoHoPython/Compilation/MemoryAnalyzer.cs
+++ b/NoHoPython/Compilation/MemoryAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using NoHoPython.IntermediateRepresentation;
+using System.Text;
 
 namespace NoHoPython.Compilation
 {
@@ -23,7 +24,7 @@ namespace NoHoPython.Compilation
             ProtectAllocFailure = protectAllocFailure;
         }
 
-        public void EmitAnalyzers(StringBuilder emitter)
+        public void EmitAnalyzers(StatementEmitter emitter)
         {
             if (Mode == AnalysisMode.None && !ProtectAllocFailure)
                 return;

--- a/NoHoPython/Compilation/Statements/Conditional.cs
+++ b/NoHoPython/Compilation/Statements/Conditional.cs
@@ -86,6 +86,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 statement.Emit(irProgram, emitter, typeargs, indent + 1);
             });
 
+            emitter.LastSourceLocation = BlockBeginLocation;
             if (!CodeBlockAllCodePathsReturn())
             {
                 foreach (Variable declaration in LocalVariables)

--- a/NoHoPython/Compilation/Statements/EnumDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/EnumDeclaration.cs
@@ -36,7 +36,7 @@ namespace NoHoPython.IntermediateRepresentation
         private List<EnumType> usedEnumTypes;
         public readonly Dictionary<EnumDeclaration, List<EnumType>> EnumTypeOverloads;
 
-        public void ForwardDeclareEnumTypes(StringBuilder emitter)
+        public void ForwardDeclareEnumTypes(StatementEmitter emitter)
         {
             foreach (EnumType usedEnum in usedEnumTypes)
             {
@@ -58,7 +58,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void ForwardDeclareType(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclareType(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.EnumTypeOverloads.ContainsKey(this))
                 return;
@@ -67,7 +67,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 enumType.EmitCStruct(irProgram, emitter);
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.EnumTypeOverloads.ContainsKey(this))
                 return;
@@ -88,7 +88,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (!irProgram.EnumTypeOverloads.ContainsKey(this))
                 return;
@@ -121,13 +121,13 @@ namespace NoHoPython.Typing
         public string GetStandardIdentifier(IRProgram irProgram) => $"_nhp_enum_{IScopeSymbol.GetAbsolouteName(EnumDeclaration)}_empty_option_{Name}";
         public string GetCName(IRProgram irProgram) => throw new CannotCompileEmptyTypeError(null);
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }
@@ -141,13 +141,13 @@ namespace NoHoPython.Typing
 
         public string GetCName(IRProgram irProgram) => EnumDeclaration.IsEmpty ? $"{GetStandardIdentifier(irProgram)}_options_t" : $"{GetStandardIdentifier(irProgram)}_t";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
         {
             if(RequiresDisposal)
-                emitter.AppendLine($"free_enum{GetStandardIdentifier(irProgram)}({valueCSource});");
+                emitter.Append($"free_enum{GetStandardIdentifier(irProgram)}({valueCSource});");
         }
 
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
         {
             if (RequiresDisposal)
             {
@@ -160,7 +160,7 @@ namespace NoHoPython.Typing
                 emitter.Append(valueCSource);
         }
 
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource)
         {
             if (RequiresDisposal)
             {
@@ -173,11 +173,11 @@ namespace NoHoPython.Typing
                 emitter.Append($"({destC} = {valueCSource})");
         }
 
-        public void EmitGetProperty(IRProgram irProgram, StringBuilder emitter, string valueCSource, Property property) => emitter.Append($"get_{property.Name}{GetStandardIdentifier(irProgram)}({valueCSource})");
+        public void EmitGetProperty(IRProgram irProgram, IEmitter emitter, string valueCSource, Property property) => emitter.Append($"get_{property.Name}{GetStandardIdentifier(irProgram)}({valueCSource})");
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(EnumDeclaration.IsEmpty ? valueCSource : $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})");
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(EnumDeclaration.IsEmpty ? valueCSource : $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})");
 
         public string GetCEnumOptionForType(IRProgram irProgram, IType type) => $"{GetStandardIdentifier(irProgram)}OPTION_{type.GetStandardIdentifier(irProgram)}";
 
@@ -190,7 +190,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this) || EnumDeclaration.IsEmpty)
                 return;
@@ -207,7 +207,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitOptionsCEnum(IRProgram irProgram, StringBuilder emitter)
+        public void EmitOptionsCEnum(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.AppendLine($"typedef enum {GetStandardIdentifier(irProgram)}_options {{");
             for(int i = 0; i < options.Value.Count; i++)
@@ -222,7 +222,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine($"{GetStandardIdentifier(irProgram)}_options_t;");
         }
 
-        public void EmitMarshallerHeaders(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMarshallerHeaders(IRProgram irProgram, StatementEmitter emitter)
         {
             if (EnumDeclaration.IsEmpty)
                 return;
@@ -236,13 +236,13 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitPropertyGetHeaders(IRProgram irProgram, StringBuilder emitter)
+        public void EmitPropertyGetHeaders(IRProgram irProgram, StatementEmitter emitter)
         {
             foreach (Property property in globalSupportedProperties[this].Value.Values)
                 emitter.AppendLine($"{property.Type.GetCName(irProgram)} get_{property.Name}{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum);");
         }
 
-        public void EmitMarshallers(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMarshallers(IRProgram irProgram, StatementEmitter emitter)
         {
             if (EnumDeclaration.IsEmpty)
                 return;
@@ -266,7 +266,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitPropertyGetters(IRProgram irProgram, StringBuilder emitter)
+        public void EmitPropertyGetters(IRProgram irProgram, StatementEmitter emitter)
         {
             foreach (Property property in globalSupportedProperties[this].Value.Values)
             {
@@ -285,7 +285,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitDestructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.AppendLine($"void free_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum) {{");
             emitter.AppendLine("\tswitch(_nhp_enum.option) {");
@@ -295,13 +295,14 @@ namespace NoHoPython.Typing
                     emitter.AppendLine($"\tcase {GetCEnumOptionForType(irProgram, option)}:");
                     emitter.Append("\t\t");
                     option.EmitFreeValue(irProgram, emitter, $"_nhp_enum.data.{option.GetStandardIdentifier(irProgram)}_set", "NULL");
+                    emitter.AppendLine();
                     emitter.AppendLine("\t\tbreak;");
                 }
             emitter.AppendLine("\t}");
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.Append($"{GetCName(irProgram)} copy_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum");
 
@@ -328,7 +329,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitMover(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
@@ -336,12 +337,13 @@ namespace NoHoPython.Typing
             emitter.AppendLine($"{GetCName(irProgram)} move_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src) {{");
             emitter.Append('\t');
             EmitFreeValue(irProgram, emitter, "*dest", "NULL");
+            emitter.AppendLine();
             emitter.AppendLine($"\t*dest = src;");
             emitter.AppendLine("\treturn src;");
             emitter.AppendLine("}");
         }
 
-        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StringBuilder emitter)
+        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!MustSetResponsibleDestroyer)
                 return;
@@ -363,7 +365,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitOptionTypeNames(IRProgram irProgram, StringBuilder emitter)
+        public void EmitOptionTypeNames(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.NameRuntimeTypes)
                 return;
@@ -394,7 +396,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Value.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             EnumType realPrototype = (EnumType)TargetType.SubstituteWithTypearg(typeargs);
 
@@ -408,11 +410,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, emitter, typeargs, responsibleDestroyer);
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), responsibleDestroyer);
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), responsibleDestroyer);
                 emitter.Append(')');
             }
         }
@@ -428,7 +426,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             EnumValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if (!irProgram.EmitExpressionStatements)
                 throw new InvalidOperationException();
@@ -494,7 +492,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             EnumValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             EnumType enumType = (EnumType)EnumValue.Type.SubstituteWithTypearg(typeargs);
 

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -136,7 +136,7 @@ namespace NoHoPython.IntermediateRepresentation
 
             foreach (var uniqueProcedure in uniqueProcedureTypes)
             {
-                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src);");
+                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src, void* child_agent);");
             }
         }
 
@@ -147,9 +147,9 @@ namespace NoHoPython.IntermediateRepresentation
 
             foreach (var uniqueProcedure in uniqueProcedureTypes)
             {
-                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src) {{");
+                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src, void* child_agent) {{");
                 emitter.Append('\t');
-                uniqueProcedure.Item1.EmitFreeValue(this, emitter, "*dest", "NULL");
+                uniqueProcedure.Item1.EmitFreeValue(this, emitter, "*dest", "child_agent");
                 emitter.AppendLine();
                 emitter.AppendLine("\t*dest = src;");
                 emitter.AppendLine("\treturn src;");
@@ -206,12 +206,12 @@ namespace NoHoPython.Typing
         public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => emitter.Append($"({valueCSource})->_nhp_destructor({valueCSource});"); 
         public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"({valueCSource})->_nhp_copier({valueCSource}, {responsibleDestroyer})");
         
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (irProgram.EmitExpressionStatements)
-                IType.EmitMoveExpressionStatement(this, irProgram, emitter, destC, valueCSource);
+                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
             else
-                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource})");
+                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
         }
 
         public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);

--- a/NoHoPython/Compilation/Statements/Variables.cs
+++ b/NoHoPython/Compilation/Statements/Variables.cs
@@ -1,7 +1,6 @@
 ﻿using NoHoPython.IntermediateRepresentation;
 using NoHoPython.IntermediateRepresentation.Statements;
 using NoHoPython.Typing;
-using System.Text;
 
 namespace NoHoPython.Scoping
 {

--- a/NoHoPython/Compilation/Statements/Variables.cs
+++ b/NoHoPython/Compilation/Statements/Variables.cs
@@ -7,12 +7,13 @@ namespace NoHoPython.Scoping
 {
     partial class Variable
     {
-        public void EmitCFree(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void EmitCFree(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (Type.SubstituteWithTypearg(typeargs).RequiresDisposal)
             {
                 CodeBlock.CIndent(emitter, indent + 1);
                 Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, GetStandardIdentifier(), "NULL");
+                emitter.AppendLine();
             }
         }
     }
@@ -26,7 +27,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => Type.SubstituteWithTypearg(typeargs).ScopeForUsedTypes(irBuilder);
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer) => emitter.Append(Variable.GetStandardIdentifier());
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer) => emitter.Append(Variable.GetStandardIdentifier());
     }
 
     partial class VariableDeclaration
@@ -39,18 +40,19 @@ namespace NoHoPython.IntermediateRepresentation.Values
             InitialValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void EmitCDecl(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void EmitCDecl(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent + 1);
             emitter.AppendLine($"{Variable.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} {Variable.GetStandardIdentifier()};");
             if (WillRevaluate && Variable.Type.SubstituteWithTypearg(typeargs).RequiresDisposal)
             {
                 CodeBlock.CIndent(emitter, indent + 1);
+                emitter.LastSourceLocation = ErrorReportedElement.SourceLocation;
                 emitter.AppendLine($"int init_{Variable.GetStandardIdentifier()} = 0;");
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             bool closeExpressionStatement = false;
             if (WillRevaluate && Variable.Type.SubstituteWithTypearg(typeargs).RequiresDisposal)
@@ -67,18 +69,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if (InitialValue.RequiresDisposal(typeargs))
                 InitialValue.Emit(irProgram, emitter, typeargs, "NULL");
             else
-            {
-                StringBuilder valueBuilder = new();
-                InitialValue.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), "NULL");
-            }
+                Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(InitialValue, irProgram, typeargs, "NULL"), "NULL");
             emitter.Append(')');
 
             if (closeExpressionStatement)
                 emitter.Append(";})");
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             Emit(irProgram, emitter, typeargs, "NULL");
@@ -96,22 +94,21 @@ namespace NoHoPython.IntermediateRepresentation.Values
             SetValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
-            StringBuilder valueBuilder = new();
-            SetValue.Emit(irProgram, valueBuilder, typeargs, "NULL");
+            string setValueCSource = BufferedEmitter.EmitBufferedValue(SetValue, irProgram, typeargs, "NULL");
 
             if (SetValue.RequiresDisposal(typeargs))
-                Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), valueBuilder.ToString());
+                Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), setValueCSource);
             else
             {
-                StringBuilder copyBuilder = new();
-                Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, copyBuilder, valueBuilder.ToString(), "NULL");
+                BufferedEmitter copyBuilder = new();
+                Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, copyBuilder, setValueCSource, "NULL");
                 Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), copyBuilder.ToString());
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             Emit(irProgram, emitter, typeargs, "NULL");
@@ -125,7 +122,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             emitter.Append(CSymbol.Name);
         }
@@ -138,6 +135,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
     {
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => CSymbol.Type.SubstituteWithTypearg(typeargs).ScopeForUsedTypes(irBuilder);
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
     }
 }

--- a/NoHoPython/Compilation/Statements/Variables.cs
+++ b/NoHoPython/Compilation/Statements/Variables.cs
@@ -99,12 +99,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
             string setValueCSource = BufferedEmitter.EmitBufferedValue(SetValue, irProgram, typeargs, "NULL");
 
             if (SetValue.RequiresDisposal(typeargs))
-                Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), setValueCSource);
+                Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), setValueCSource, "NULL");
             else
             {
                 BufferedEmitter copyBuilder = new();
                 Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, copyBuilder, setValueCSource, "NULL");
-                Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), copyBuilder.ToString());
+                Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, Variable.GetStandardIdentifier(), copyBuilder.ToString(), "NULL");
             }
         }
 

--- a/NoHoPython/Compilation/Types/Arrays.cs
+++ b/NoHoPython/Compilation/Types/Arrays.cs
@@ -173,7 +173,7 @@ namespace NoHoPython.Typing
 
         public void EmitMarshaller(IRProgram irProgram, StatementEmitter emitter)
         {
-            emitter.Append($"{GetCName(irProgram)}       {GetStandardIdentifier(irProgram)}({ElementType.GetCName(irProgram)}* buffer, int length");
+            emitter.Append($"{GetCName(irProgram)} marshal{GetStandardIdentifier(irProgram)}({ElementType.GetCName(irProgram)}* buffer, int length");
 
             if (MustSetResponsibleDestroyer)
                 emitter.Append(", void* responsible_destroyer");

--- a/NoHoPython/Compilation/Types/BasicTypes.cs
+++ b/NoHoPython/Compilation/Types/BasicTypes.cs
@@ -6,9 +6,10 @@ namespace NoHoPython.Typing
 {
     partial interface IType
     {
-        public static void EmitMoveExpressionStatement(IType type, IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public static void EmitMoveExpressionStatement(IType type, IRProgram irProgram, IEmitter emitter, string destC, string valueCSource)
         {
-            Debug.Assert(irProgram.EmitExpressionStatements);
+            if (!irProgram.EmitExpressionStatements)
+                throw new CannotEmitDestructorError(null);
 
             emitter.Append($"({{{type.GetCName(irProgram)} _nhp_es_move_temp = {destC}; {destC} = {valueCSource}; ");
             type.EmitFreeValue(irProgram, emitter, "_nhp_es_move_temp", "NULL");
@@ -25,15 +26,15 @@ namespace NoHoPython.Typing
         public abstract string GetCName(IRProgram irProgram);
         public string GetStandardIdentifier(IRProgram irProgram) => TypeName;
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) { }
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => emitter.Append(valueCSource);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => emitter.Append($"({destC} = {valueCSource})");
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) { }
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append(valueCSource);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => emitter.Append($"({destC} = {valueCSource})");
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
 
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(valueCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(valueCSource);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }
@@ -72,13 +73,13 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram) => "void";
         public string GetStandardIdentifier(IRProgram irProgram) => "nothing";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }

--- a/NoHoPython/Compilation/Types/BasicTypes.cs
+++ b/NoHoPython/Compilation/Types/BasicTypes.cs
@@ -1,18 +1,16 @@
 ﻿using NoHoPython.IntermediateRepresentation;
-using System.Diagnostics;
-using System.Text;
 
 namespace NoHoPython.Typing
 {
     partial interface IType
     {
-        public static void EmitMoveExpressionStatement(IType type, IRProgram irProgram, IEmitter emitter, string destC, string valueCSource)
+        public static void EmitMove(IType type, IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (!irProgram.EmitExpressionStatements)
                 throw new CannotEmitDestructorError(null);
-
+            
             emitter.Append($"({{{type.GetCName(irProgram)} _nhp_es_move_temp = {destC}; {destC} = {valueCSource}; ");
-            type.EmitFreeValue(irProgram, emitter, "_nhp_es_move_temp", "NULL");
+            type.EmitFreeValue(irProgram, emitter, "_nhp_es_move_temp", childAgent);
             emitter.Append($" {destC};}})");
         }
     }
@@ -28,7 +26,7 @@ namespace NoHoPython.Typing
 
         public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) { }
         public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append(valueCSource);
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => emitter.Append($"({destC} = {valueCSource})");
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => emitter.Append($"({destC} = {valueCSource})");
         public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
         public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
@@ -75,7 +73,7 @@ namespace NoHoPython.Typing
 
         public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
         public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
         public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
         public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);

--- a/NoHoPython/Compilation/Types/TypeParameters.cs
+++ b/NoHoPython/Compilation/Types/TypeParameters.cs
@@ -16,7 +16,7 @@ namespace NoHoPython.Typing
 
         public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);

--- a/NoHoPython/Compilation/Types/TypeParameters.cs
+++ b/NoHoPython/Compilation/Types/TypeParameters.cs
@@ -14,14 +14,14 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public string GetStandardIdentifier(IRProgram irProgram) => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) => throw new UnexpectedTypeParameterError(TypeParameter, null);
     }
 }

--- a/NoHoPython/Compilation/Values/Arithmetic.cs
+++ b/NoHoPython/Compilation/Values/Arithmetic.cs
@@ -13,7 +13,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Input.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             void EmitCCast(string castTo)
             {
@@ -53,7 +53,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class ArithmeticOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             if (Operation == ArithmeticOperation.Exponentiate)
             {
@@ -100,7 +100,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             ArrayValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             void EmitOp()
             {

--- a/NoHoPython/Compilation/Values/InterpolatedString.cs
+++ b/NoHoPython/Compilation/Values/InterpolatedString.cs
@@ -7,20 +7,20 @@ namespace NoHoPython.Typing
     partial interface IType
     {
         public string GetFormatSpecifier(IRProgram irProgram);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource);
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource);
     }
 
     partial class Primitive
     {
         public abstract string GetFormatSpecifier(IRProgram irProgram);
-        public virtual void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => emitter.Append(valueCSource);
+        public virtual void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => emitter.Append(valueCSource);
     }
 
     partial class ArrayType
     {
         public string GetFormatSpecifier(IRProgram irProgram) => ElementType.IsCompatibleWith(Primitive.Character) ? "%.*s" : "%p";
 
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource)
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource)
         {
             if (!ElementType.IsCompatibleWith(Primitive.Character))
                 emitter.Append("(void*)");
@@ -39,7 +39,7 @@ namespace NoHoPython.Typing
     {
         public override string GetFormatSpecifier(IRProgram irProgram) => "%s";
 
-        public override void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => emitter.Append($"(({valueCSource}) ? \"true\" : \"false\")");
+        public override void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => emitter.Append($"(({valueCSource}) ? \"true\" : \"false\")");
     }
 
     partial class CharacterType
@@ -65,43 +65,43 @@ namespace NoHoPython.Typing
     partial class EmptyEnumOption
     {
         public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class EnumType
     {
         public string GetFormatSpecifier(IRProgram irProgram) => irProgram.NameRuntimeTypes ? "%s" : throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => emitter.Append(irProgram.NameRuntimeTypes ? $"{GetStandardIdentifier(irProgram)}_typenames[(int){valueCSource}.option]" : throw new InvalidOperationException());
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => emitter.Append(irProgram.NameRuntimeTypes ? $"{GetStandardIdentifier(irProgram)}_typenames[(int){valueCSource}.option]" : throw new InvalidOperationException());
     }
 
     partial class RecordType
     {
         public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class InterfaceType
     {
         public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class ProcedureType
     {
         public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class NothingType
     {
         public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class TypeParameterReference
     {
         public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public void EmitFormatValue(IRProgram irProgram, IEmitter emitter, string valueCSource) => throw new InvalidOperationException();
     }
 }
 
@@ -119,13 +119,13 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => true;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if (!irProgram.EmitExpressionStatements)
                 throw new CannotEmitInterpolatedString(this);
 
             irProgram.ExpressionDepth++;
-            StringBuilder formatBuilder = new();
+            BufferedEmitter formatBuilder = new();
             List<IRValue> arguments = new();
             SortedSet<int> bufferedArguments = new();
             void emitFormatValues()
@@ -136,11 +136,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     if (bufferedArguments.Contains(i))
                         arguments[i].Type.EmitFormatValue(irProgram, emitter, $"intpd_buffered_arg{i}{irProgram.ExpressionDepth}");
                     else
-                    {
-                        StringBuilder valueBuilder = new();
-                        arguments[i].Emit(irProgram, valueBuilder, typeargs, "NULL");
-                        arguments[i].Type.EmitFormatValue(irProgram, emitter, valueBuilder.ToString());
-                    }
+                        arguments[i].Type.EmitFormatValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(arguments[i], irProgram, typeargs, "NULl"));
                 }
             }
 

--- a/NoHoPython/Compilation/Values/InterpolatedString.cs
+++ b/NoHoPython/Compilation/Values/InterpolatedString.cs
@@ -164,9 +164,9 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 emitter.Append(';');
             }
 
-            emitter.Append($"intpd_str{irProgram.ExpressionDepth}.length = snprintf(NULL, 0, \"{formatBuilder.ToString()}\"");
+            emitter.Append($"intpd_str{irProgram.ExpressionDepth}.length = snprintf(NULL, 0, \"{formatBuilder}\"");
             emitFormatValues();
-            emitter.Append($"); intpd_str{irProgram.ExpressionDepth}.buffer = {irProgram.MemoryAnalyzer.Allocate($"intpd_str{irProgram.ExpressionDepth}.length + 1")}; snprintf(intpd_str{irProgram.ExpressionDepth}.buffer, intpd_str{irProgram.ExpressionDepth}.length + 1, \"{formatBuilder.ToString()}\"");
+            emitter.Append($"); intpd_str{irProgram.ExpressionDepth}.buffer = {irProgram.MemoryAnalyzer.Allocate($"intpd_str{irProgram.ExpressionDepth}.length + 1")}; snprintf(intpd_str{irProgram.ExpressionDepth}.buffer, intpd_str{irProgram.ExpressionDepth}.length + 1, \"{formatBuilder}\"");
             emitFormatValues();
             emitter.Append(");");
 

--- a/NoHoPython/Compilation/Values/Operators.cs
+++ b/NoHoPython/Compilation/Values/Operators.cs
@@ -17,10 +17,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
-            StringBuilder leftBuilder = new();
-            StringBuilder rightBuilder = new();
+            BufferedEmitter leftBuilder = new();
+            BufferedEmitter rightBuilder = new();
 
             if((!ShortCircuit && (!Left.IsPure && !Right.IsConstant) || (!Right.IsPure && !Left.IsConstant))
                 || Left.RequiresDisposal(typeargs) || Right.RequiresDisposal(typeargs))
@@ -54,12 +54,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
             } 
         }
 
-        public abstract void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource);
+        public abstract void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource);
     }
 
     partial class ComparativeOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             emitter.Append($"({leftCSource}");
             switch (Operation)
@@ -89,7 +89,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class LogicalOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             emitter.Append($"({leftCSource} ");
             switch (Operation)
@@ -107,7 +107,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class BitwiseOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             emitter.Append($"({leftCSource} ");
             switch (Operation)
@@ -143,7 +143,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if ((!Array.IsPure && !Index.IsConstant) ||
                 (!Index.IsPure && !Array.IsConstant))
@@ -196,7 +196,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if ((!Array.IsPure && (!Index.IsConstant || !Value.IsConstant)) ||
                (!Index.IsPure && (!Array.IsConstant || !Value.IsConstant)) ||
@@ -217,15 +217,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     IRValue.EmitMemorySafe(Index, irProgram, emitter, typeargs);
 
                 emitter.Append(';');
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, valueBuilder, typeargs, $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
                 else
-                {
-                    StringBuilder toCopyBuilder = new();
-                    Value.Emit(irProgram, toCopyBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, toCopyBuilder.ToString(), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
 
                 Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"arr{irProgram.ExpressionDepth}.buffer[ind{irProgram.ExpressionDepth}]", valueBuilder.ToString());
                 emitter.Append(";})");
@@ -234,7 +230,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
             else
             {
-                StringBuilder destBuilder = new();
+                BufferedEmitter destBuilder = new();
                 IRValue.EmitMemorySafe(Array, irProgram, destBuilder, typeargs);
                 if (irProgram.DoBoundsChecking)
                 {
@@ -249,25 +245,21 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     destBuilder.Append(']');
                 }
 
-                StringBuilder arrayResponsibleDestructor = new();
+                BufferedEmitter arrayResponsibleDestructor = new();
                 IRValue.EmitMemorySafe(Array.GetPostEvalPure(), irProgram, arrayResponsibleDestructor, typeargs);
                 arrayResponsibleDestructor.Append(".responsible_destroyer");
 
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, valueBuilder, typeargs, arrayResponsibleDestructor.ToString());
                 else
-                {
-                    StringBuilder toCopyBuilder = new();
-                    Value.Emit(irProgram, toCopyBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, toCopyBuilder.ToString(), arrayResponsibleDestructor.ToString());
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), arrayResponsibleDestructor.ToString());
 
                 Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, destBuilder.ToString(), valueBuilder.ToString());
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
 
@@ -290,15 +282,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     IRValue.EmitMemorySafe(Index, irProgram, emitter, typeargs);
                 emitter.AppendLine(";");
 
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, valueBuilder, typeargs, "arr.responsible_destroyer");
                 else
-                {
-                    StringBuilder toCopyBuilder = new();
-                    Value.Emit(irProgram, toCopyBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, toCopyBuilder.ToString(), "arr.responsible_destroyer");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), "arr.responsible_destroyer");
 
                 CodeBlock.CIndent(emitter, indent + 1);
                 Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, "arr.buffer[ind]", valueBuilder.ToString());
@@ -324,13 +312,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
-            StringBuilder valueBuilder = new();
-            IRValue.EmitMemorySafe(Record, irProgram, valueBuilder, typeargs);
-
             if (Record.Type.SubstituteWithTypearg(typeargs) is IPropertyContainer propertyContainer)
-                propertyContainer.EmitGetProperty(irProgram, emitter, valueBuilder.ToString(), Property);
+                propertyContainer.EmitGetProperty(irProgram, emitter, BufferedEmitter.EmittedBufferedMemorySafe(Record, irProgram, typeargs), Property);
             else
                 throw new UnexpectedTypeException(Record.Type.SubstituteWithTypearg(typeargs), ErrorReportedElement);
         }
@@ -347,7 +332,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if ((!Record.IsPure && !Value.IsConstant) || (!Value.IsPure && !Record.IsConstant))
             {
@@ -360,11 +345,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, emitter, typeargs, $"record{irProgram.ExpressionDepth}");
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), $"record{irProgram.ExpressionDepth}");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), $"record{irProgram.ExpressionDepth}");
 
                 emitter.Append(';');
                 if (IsInitializingProperty)
@@ -379,42 +360,31 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
             else
             {
-                StringBuilder recordBuilder = new();
-                IRValue.EmitMemorySafe(Record, irProgram, recordBuilder, typeargs);
-
-                StringBuilder recordResponsibleDestroyer = new();
-                IRValue.EmitMemorySafe(Record.GetPostEvalPure(), irProgram, recordResponsibleDestroyer, typeargs);
+                string recordCSource = BufferedEmitter.EmittedBufferedMemorySafe(Record, irProgram, typeargs);
+                string recordResponsibleDestroyer = BufferedEmitter.EmittedBufferedMemorySafe(Record.GetPostEvalPure(), irProgram, typeargs);
 
                 if (IsInitializingProperty)
                 {
-                    emitter.Append($"({recordBuilder}->{Property.Name} = ");
+                    emitter.Append($"({recordCSource}->{Property.Name} = ");
                     if (Value.RequiresDisposal(typeargs))
-                        Value.Emit(irProgram, emitter, typeargs, recordResponsibleDestroyer.ToString());
+                        Value.Emit(irProgram, emitter, typeargs, recordResponsibleDestroyer);
                     else
-                    {
-                        StringBuilder valueBuilder = new();
-                        Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), recordResponsibleDestroyer.ToString());
-                    }
+                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), recordResponsibleDestroyer.ToString());
                     emitter.Append(')');
                 }
                 else
                 {
-                    StringBuilder toCopyBuilder = new();
+                    BufferedEmitter toCopyBuilder = new();
                     if (Value.RequiresDisposal(typeargs))
                         Value.Emit(irProgram, toCopyBuilder, typeargs, recordResponsibleDestroyer.ToString());
                     else
-                    {
-                        StringBuilder valueBuilder = new();
-                        Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, toCopyBuilder, valueBuilder.ToString(), recordResponsibleDestroyer.ToString());
-                    }
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"{recordBuilder}->{Property.Name}", toCopyBuilder.ToString());
+                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, toCopyBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), recordResponsibleDestroyer.ToString());
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"{recordCSource}->{Property.Name}", toCopyBuilder.ToString());
                 }
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             if ((!Record.IsPure && !Value.IsConstant) || (!Value.IsPure && !Record.IsConstant))
@@ -431,11 +401,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, emitter, typeargs, "record");
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), "record");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), "record");
                 emitter.AppendLine(";");
 
                 CodeBlock.CIndent(emitter, indent + 1);
@@ -462,7 +428,7 @@ namespace NoHoPython.Typing
 {
     partial class ArrayType
     {
-        public static void EmitBoundsCheckedIndex(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, IRValue array, IRValue index, Syntax.IAstElement errorReportedElement)
+        public static void EmitBoundsCheckedIndex(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, IRValue array, IRValue index, Syntax.IAstElement errorReportedElement)
         {
             emitter.Append("_nhp_bounds_check(");
             IRValue.EmitMemorySafe(index, irProgram, emitter, typeargs);

--- a/NoHoPython/Compilation/Values/Operators.cs
+++ b/NoHoPython/Compilation/Values/Operators.cs
@@ -223,7 +223,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 else
                     Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
 
-                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"arr{irProgram.ExpressionDepth}.buffer[ind{irProgram.ExpressionDepth}]", valueBuilder.ToString());
+                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"arr{irProgram.ExpressionDepth}.buffer[ind{irProgram.ExpressionDepth}]", valueBuilder.ToString(), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
                 emitter.Append(";})");
 
                 irProgram.ExpressionDepth--;
@@ -255,7 +255,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 else
                     Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), arrayResponsibleDestructor.ToString());
 
-                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, destBuilder.ToString(), valueBuilder.ToString());
+                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, destBuilder.ToString(), valueBuilder.ToString(), arrayResponsibleDestructor.ToString());
             }
         }
 
@@ -289,7 +289,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), "arr.responsible_destroyer");
 
                 CodeBlock.CIndent(emitter, indent + 1);
-                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, "arr.buffer[ind]", valueBuilder.ToString());
+                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, "arr.buffer[ind]", valueBuilder.ToString(), "arr.responsible_destroyer");
                 emitter.AppendLine(";");
                 CodeBlock.CIndent(emitter, indent);
                 emitter.AppendLine("}");
@@ -352,7 +352,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     emitter.Append($"(record{irProgram.ExpressionDepth}->{Property.Name} = value{irProgram.ExpressionDepth});}})");
                 else
                 {
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record{irProgram.ExpressionDepth}->{Property.Name}", $"value{irProgram.ExpressionDepth}");
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record{irProgram.ExpressionDepth}->{Property.Name}", $"value{irProgram.ExpressionDepth}", $"record{irProgram.ExpressionDepth}");
                     emitter.Append(";})");
                 }
                 
@@ -379,7 +379,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                         Value.Emit(irProgram, toCopyBuilder, typeargs, recordResponsibleDestroyer.ToString());
                     else
                         Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, toCopyBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), recordResponsibleDestroyer.ToString());
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"{recordCSource}->{Property.Name}", toCopyBuilder.ToString());
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"{recordCSource}->{Property.Name}", toCopyBuilder.ToString(), recordCSource);
                 }
             }
         }
@@ -409,7 +409,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     emitter.AppendLine($"record->{Property.Name} = value;");
                 else
                 {
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record->{Property.Name}", "value");
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record->{Property.Name}", "value", "record");
                     emitter.AppendLine(";");
                 }
                 CodeBlock.CIndent(emitter, indent);

--- a/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
@@ -21,15 +21,17 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         private List<VariableDeclaration> DeclaredVariables;
 
         public bool IsLoop { get; private set; }
-
         public int? BreakLabelId { get; private set; }
 
-        public CodeBlock(SymbolContainer parent, bool isLoop) : base(parent)
+        public SourceLocation BlockBeginLocation { get; private set; }
+
+        public CodeBlock(SymbolContainer parent, bool isLoop, SourceLocation blockBeginLocation) : base(parent)
         {
+            IsLoop = isLoop;
+            BlockBeginLocation = blockBeginLocation;
             Statements = null;
             LocalVariables = new List<Variable>();
             DeclaredVariables = new List<VariableDeclaration>();
-            IsLoop = isLoop;
         }
 
         public void AddVariableDeclaration(VariableDeclaration variableDeclaration)

--- a/NoHoPython/IntermediateRepresentation/Statements/Conditional.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Conditional.cs
@@ -205,13 +205,13 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, IfTrueBlock);
             irBuilder.SymbolMarshaller.GoBack();
 
             if (NextIf != null)
             {
-                scopedNextIf = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+                scopedNextIf = irBuilder.SymbolMarshaller.NewCodeBlock(false, NextIf.SourceLocation);
                 NextIf.ForwardDeclare(irBuilder);
                 irBuilder.SymbolMarshaller.GoBack();
             }
@@ -250,7 +250,7 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedToExecute = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+            scopedToExecute = irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, ToExecute);
             irBuilder.SymbolMarshaller.GoBack();
         }
@@ -274,7 +274,7 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true);
+            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, ToExecute);
             irBuilder.SymbolMarshaller.GoBack();
         }
@@ -299,7 +299,7 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true);
+            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, ToExecute);
             irBuilder.SymbolMarshaller.GoBack();
         }
@@ -329,13 +329,13 @@ namespace NoHoPython.Syntax.Statements
         {
             handlerCodeBlocks = new Dictionary<MatchHandler, CodeBlock>();
             MatchHandlers.ForEach((handler) => {
-                handlerCodeBlocks.Add(handler, irBuilder.SymbolMarshaller.NewCodeBlock(false));
+                handlerCodeBlocks.Add(handler, irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation));
                 IAstStatement.ForwardDeclareBlock(irBuilder, handler.Statements);
                 irBuilder.SymbolMarshaller.GoBack();
             });
             if(DefaultHandler != null)
             {
-                defaultHandlerCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+                defaultHandlerCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation);
                 IAstStatement.ForwardDeclareBlock(irBuilder, DefaultHandler);
                 irBuilder.SymbolMarshaller.GoBack();
             }

--- a/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
@@ -70,7 +70,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public IType? ReturnType { get; private set; }
 
-        public ProcedureDeclaration(string name, List<Typing.TypeParameter> typeParameters, IType? returnType, SymbolContainer parentContainer, IScopeSymbol? lastMasterScope, IAstElement errorReportedElement) : base(parentContainer, false)
+        public ProcedureDeclaration(string name, List<Typing.TypeParameter> typeParameters, IType? returnType, SymbolContainer parentContainer, IScopeSymbol? lastMasterScope, IAstElement errorReportedElement) : base(parentContainer, false, errorReportedElement.SourceLocation)
         {
             Name = name;
             TypeParameters = typeParameters;

--- a/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
@@ -37,7 +37,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public List<Property> GetProperties();
 
-        public void EmitGetProperty(IRProgram irProgram, StringBuilder emitter, string valueCSource, Property property);
+        public void EmitGetProperty(IRProgram irProgram, IEmitter emitter, string valueCSource, Property property);
     }
 
     public abstract class Property

--- a/NoHoPython/IntermediateRepresentation/Values/Literals.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Literals.cs
@@ -176,7 +176,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 else if (interpolatedValues[i] is string str)
                 {
                     if (str != string.Empty)
-                        InterpolatedValues.Add(i);
+                        InterpolatedValues.Add(str);
                 }
                 else
                     throw new InvalidOperationException();

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -77,7 +77,7 @@ public static class Program
             Console.WriteLine($"Compilation succesfully finished, taking {DateTime.Now - compileStart}. Output is in {outputFile}.");
             if (program.EmitLineDirectives)
             {
-                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it. Please not that this feature doesn't work very well at the moment, and is still experimental.");
+                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it. Please not that this feature doesn't work very well at the moment, and is still experimental. In addition, unless you want to debug internal gdb code, type \"skip file {outputFile}\", then run.");
             }
         }
         catch (SyntaxError syntaxError)

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -65,19 +65,15 @@ public static class Program
             else
                 outputFile = "out.c";
 
-            StringBuilder output = new();
             if (args.Contains("-header"))
             {
                 string headerName = outputFile.EndsWith(".c") ? outputFile.Replace(".c", ".h") : outputFile + ".h";
-                StringBuilder headerBuilder = new();
                 program.IncludeCFile(headerName);
-                program.Emit(output, headerBuilder);
-                File.WriteAllText(headerName, headerBuilder.ToString());
+                program.Emit(outputFile, headerName);
             }
             else
-                program.Emit(output, output);
+                program.Emit(outputFile, null);
 
-            File.WriteAllText(outputFile, output.ToString());
             Console.WriteLine($"Compilation succesfully finished, taking {DateTime.Now - compileStart}. Output is in {outputFile}.");
             if (program.EmitLineDirectives)
             {

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert\r\n-linedir"
+      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert\r\n-linedir\r\n-stacktrace"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert"
+      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert\r\n-linedir"
     }
   }
 }

--- a/NoHoPython/Scoping/SymbolMarshaller.cs
+++ b/NoHoPython/Scoping/SymbolMarshaller.cs
@@ -147,9 +147,9 @@ namespace NoHoPython.Scoping
             scopeStack.Push(symbolContainer);
         }
 
-        public CodeBlock NewCodeBlock(bool isLoop)
+        public CodeBlock NewCodeBlock(bool isLoop, SourceLocation blockBeginLocation)
         {
-            CodeBlock codeBlock = new(scopeStack.Peek(), isLoop);
+            CodeBlock codeBlock = new(scopeStack.Peek(), isLoop, blockBeginLocation);
             NavigateToScope(codeBlock);
             return codeBlock;
         }

--- a/NoHoPython/Scoping/SymbolMarshaller.cs
+++ b/NoHoPython/Scoping/SymbolMarshaller.cs
@@ -62,7 +62,7 @@ namespace NoHoPython.Scoping
             public void DelayedLinkSetStatements(List<IRStatement> statements) => this.statements.AddRange(statements);
 
             public void ScopeForUsedTypes(Dictionary<Typing.TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => throw new InvalidOperationException();
-            public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<Typing.TypeParameter, IType> typeargs, int indent) => throw new InvalidOperationException();
+            public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<Typing.TypeParameter, IType> typeargs, int indent) => throw new InvalidOperationException();
             public bool AllCodePathsReturn() => throw new InvalidOperationException();
 
             public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => throw new InvalidOperationException();

--- a/NoHoPython/Syntax/Ast.cs
+++ b/NoHoPython/Syntax/Ast.cs
@@ -8,7 +8,7 @@ namespace NoHoPython.Syntax
 {
     public interface IAstElement : ISourceLocatable
     { 
-        public void EmitSrcAsCString(StringBuilder emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
+        public void EmitSrcAsCString(IEmitter emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
         {
             if (this is IAstValue astValue)
                 CharacterLiteral.EmitCString(emitter, astValue.ToString(), formatStr, encapsulateWithQuotes);
@@ -59,7 +59,7 @@ namespace NoHoPython.Syntax
 
         public override string ToString() => $"File \"{File}\", row {Row}, col {Column}";
 
-        public void EmitLineDirective(StringBuilder emitter)
+        public void EmitLineDirective(IEmitter emitter)
         {
             emitter.Append($"#line {Row} ");
 
@@ -71,8 +71,6 @@ namespace NoHoPython.Syntax
             }
             else
                 CharacterLiteral.EmitCString(emitter, File, false, true);
-
-            emitter.AppendLine();
         }
     }
 

--- a/NoHoPython/Syntax/Values/Literals.cs
+++ b/NoHoPython/Syntax/Values/Literals.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using NoHoPython.IntermediateRepresentation;
+using System.Text;
 
 namespace NoHoPython.Syntax.Values
 {
@@ -72,7 +73,7 @@ namespace NoHoPython.Syntax.Values
         {
             if (IsStringLiteral)
             {
-                StringBuilder builder = new();
+                BufferedEmitter builder = new();
                 builder.Append('\"');
                 foreach (IAstValue value in Elements)
                     IntermediateRepresentation.Values.CharacterLiteral.EmitCChar(builder, ((CharacterLiteral)value).Character, false);

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -18,14 +18,14 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram);
         public string GetStandardIdentifier(IRProgram irProgram);
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer);
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer);
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder);
 

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -20,7 +20,7 @@ namespace NoHoPython.Typing
 
         public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent);
         public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent);
         public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
         public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource);
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer);


### PR DESCRIPTION
- Added support for the `#line` directive, which lets GDB perform control flow debugging on NHP source directly. Instead of seeing transpiled C code, GDB will display the corresponding lines of GDB source code directly, when...
  - Stepping through
  - Setting breakpoints
  - And printing a backtrace
- Fixed a memory issue with parent records.
  - Parent records were being destroyed when the parent record freed itself, but the child record has a non-zero ref count.