### PR TITLE
Introduced Mechanism to detect Child Record without Checking all Children

### DIFF
--- a/NoHoPython/Compilation/CallStackReporting.cs
+++ b/NoHoPython/Compilation/CallStackReporting.cs
@@ -10,7 +10,7 @@ namespace NoHoPython.Compilation
     {
         public static readonly int StackLimit = 1000;
 
-        public static void EmitReporter(StringBuilder emitter)
+        public static void EmitReporter(StatementEmitter emitter)
         {
             emitter.AppendLine($"static const char* _nhp_call_stack_src_locs[{StackLimit}];");
             emitter.AppendLine($"static const char* _nhp_call_stack_src[{StackLimit}];");
@@ -43,53 +43,60 @@ namespace NoHoPython.Compilation
             emitter.AppendLine("}");
         }
 
-        public static void EmitReportCall(StringBuilder emitter, IAstElement errorReportedElement, int indent)
+        public static void EmitReportCall(StatementEmitter emitter, IAstElement errorReportedElement, int indent)
         {
-            if(indent != -1)
-                CodeBlock.CIndent(emitter, indent);
-            
+            CodeBlock.CIndent(emitter, indent);
+            EmitReportCall(emitter, errorReportedElement);
+            emitter.AppendLine();
+        }
+
+        public static void EmitReportCall(IEmitter emitter, IAstElement errorReportedElement)
+        {
             emitter.Append("_nhp_santize_call(");
             CharacterLiteral.EmitCString(emitter, errorReportedElement.SourceLocation.ToString(), false, true);
             emitter.Append(", ");
             errorReportedElement.EmitSrcAsCString(emitter);
-
-            if(indent == -1)
-                emitter.Append(");");
-            else
-                emitter.AppendLine(");");
+            emitter.Append(");");
         }
 
-        public static void EmitReportReturn(StringBuilder emitter, int indent)
-        {
-            if (indent == -1)
-                emitter.Append("--_nhp_stack_size;");
-            else
-            {
-                CodeBlock.CIndent(emitter, indent);
-                emitter.AppendLine("--_nhp_stack_size;");
-            }
-        }
-
-        public static void EmitErrorLoc(StringBuilder emitter, IAstElement errorReportedElement, int indent=0)
+        public static void EmitReportReturn(StatementEmitter emitter, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
+            EmitReportReturn(emitter);
+            emitter.AppendLine();
+        }
+
+        public static void EmitReportReturn(IEmitter emitter) => emitter.Append("--_nhp_stack_size;");
+
+        public static void EmitErrorLoc(StatementEmitter emitter, IAstElement errorReportedElement, int indent)
+        {
+            CodeBlock.CIndent(emitter, indent);
+            EmitErrorLoc(emitter, errorReportedElement);
+            emitter.AppendLine();
+        }
+
+        public static void EmitErrorLoc(IEmitter emitter, IAstElement errorReportedElement)
+        {
             emitter.Append("_nhp_set_errloc(");
             CharacterLiteral.EmitCString(emitter, errorReportedElement.SourceLocation.ToString(), false, true);
             emitter.Append(", ");
             errorReportedElement.EmitSrcAsCString(emitter);
-            emitter.AppendLine(");");
+            emitter.Append(");");
         }
 
-        public static void EmitErrorLoc(StringBuilder emitter, string locationSrc, string src, int indent=0)
+        public static void EmitErrorLoc(StatementEmitter emitter, string locationSrc, string src, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             emitter.AppendLine($"_nhp_set_errloc({locationSrc}, {src});");
         }
 
-        public static void EmitPrintStackTrace(StringBuilder emitter, int indent=0)
+        public static void EmitPrintStackTrace(StatementEmitter emitter, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
-            emitter.AppendLine("_nhp_print_stack_trace();");
+            EmitPrintStackTrace(emitter);
+            emitter.AppendLine();
         }
+
+        public static void EmitPrintStackTrace(IEmitter emitter) => emitter.Append("_nhp_print_stack_trace();");
     }
 }

--- a/NoHoPython/Compilation/Emitters.cs
+++ b/NoHoPython/Compilation/Emitters.cs
@@ -1,0 +1,126 @@
+﻿using NoHoPython.Syntax;
+using NoHoPython.Typing;
+using System.Diagnostics;
+using System.Text;
+
+namespace NoHoPython.IntermediateRepresentation
+{
+    public interface IEmitter
+    {
+        public void Append(string str);
+        public void Append(char c);
+    }
+
+    public sealed class BufferedEmitter : IEmitter
+    {
+        public static string EmitBufferedValue(IRValue value, IRProgram irProgram, Dictionary<Typing.TypeParameter, IType> typeArgs, string responsibleDestroyer)
+        {
+            BufferedEmitter bufferedEmitter = new();
+            value.Emit(irProgram, bufferedEmitter, typeArgs, responsibleDestroyer);
+            return bufferedEmitter.ToString();
+        }
+
+        public static string EmittedBufferedMemorySafe(IRValue value, IRProgram irProgram, Dictionary<Typing.TypeParameter, IType> typeArgs)
+        {
+            BufferedEmitter bufferedEmitter = new();
+            IRValue.EmitMemorySafe(value, irProgram, bufferedEmitter, typeArgs);
+            return bufferedEmitter.ToString();
+        }
+
+        private StringBuilder builder;
+
+        public BufferedEmitter()
+        {
+            this.builder = new();
+        }
+
+        public void Append(string str)
+        {
+            Debug.Assert(!str.Contains('\n'));
+            builder.Append(str);
+        }
+
+        public void Append(char c)
+        {
+            Debug.Assert(c != '\n');
+            builder.Append(c);
+        }
+
+        public override string ToString() => builder.ToString();
+    }
+
+    public sealed class StatementEmitter : IEmitter, IDisposable
+    {
+        private StreamWriter writer;
+        private StringBuilder currentLineBuilder;
+        private IRProgram irProgram;
+
+        public SourceLocation? LastSourceLocation { get; set; }
+
+        public StatementEmitter(string outputPath, IRProgram irProgram)
+        {
+            this.irProgram = irProgram;
+
+            if (File.Exists(outputPath))
+                File.Delete(outputPath);
+
+            writer = new(new FileStream(outputPath, FileMode.OpenOrCreate, FileAccess.Write));
+            currentLineBuilder = new();
+        }
+
+        public void Append(string str)
+        {
+            Debug.Assert(!str.Contains('\n'));
+            currentLineBuilder.Append(str);
+        }
+
+        public void Append(char c)
+        {
+            Debug.Assert(c != '\n');
+            currentLineBuilder.Append(c);
+        }
+
+        public void AppendLine(string str)
+        {
+            currentLineBuilder.Append(str);
+            AppendLine();
+        }
+
+        public void AppendLine()
+        {
+            if (irProgram.EmitLineDirectives && LastSourceLocation.HasValue)
+            {
+                BufferedEmitter bufferedEmitter = new();
+                LastSourceLocation.Value.EmitLineDirective(bufferedEmitter);
+                writer.WriteLine(bufferedEmitter.ToString());
+            }
+
+            writer.WriteLine(currentLineBuilder.ToString());
+            currentLineBuilder.Clear();
+        }
+
+        #region disposing
+        private bool isDisposed = false;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (isDisposed) return;
+
+            if (disposing)
+            {
+                // free managed resources
+                writer.Close();
+                writer.Dispose();
+            }
+
+            isDisposed = true;
+        }
+        #endregion
+    }
+}

--- a/NoHoPython/Compilation/Errors.cs
+++ b/NoHoPython/Compilation/Errors.cs
@@ -39,11 +39,9 @@ namespace NoHoPython.IntermediateRepresentation
 
     public sealed class CannotEmitDestructorError : CodegenError
     {
-        public IRValue Value { get; private set; }
-
-        public CannotEmitDestructorError(IRValue value) : base(value, "Cannot emit destructor for value. Please move to a variable, or consider enabling expression-statements.")
+        public CannotEmitDestructorError(IRElement? errorReportedElement) : base(errorReportedElement, "Cannot emit destructor for value. Please move to a variable, or consider enabling expression-statements.")
         {
-            Value = value;
+
         }
     }
 

--- a/NoHoPython/Compilation/MemoryAnalyzer.cs
+++ b/NoHoPython/Compilation/MemoryAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using NoHoPython.IntermediateRepresentation;
+using System.Text;
 
 namespace NoHoPython.Compilation
 {
@@ -23,7 +24,7 @@ namespace NoHoPython.Compilation
             ProtectAllocFailure = protectAllocFailure;
         }
 
-        public void EmitAnalyzers(StringBuilder emitter)
+        public void EmitAnalyzers(StatementEmitter emitter)
         {
             if (Mode == AnalysisMode.None && !ProtectAllocFailure)
                 return;

--- a/NoHoPython/Compilation/Statements/Conditional.cs
+++ b/NoHoPython/Compilation/Statements/Conditional.cs
@@ -76,7 +76,15 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             if (Statements == null)
                 throw new InvalidOperationException();
 
-            Statements.ForEach((statement) => statement.Emit(irProgram, emitter, typeargs, indent + 1));
+            Statements.ForEach((statement) =>
+            {
+                if(irProgram.EmitLineDirectives)
+                {
+                    CodeBlock.CIndent(emitter, indent + 1);
+                    statement.ErrorReportedElement.SourceLocation.EmitLineDirective(emitter);
+                }
+                statement.Emit(irProgram, emitter, typeargs, indent + 1);
+            });
 
             if (!CodeBlockAllCodePathsReturn())
             {

--- a/NoHoPython/Compilation/Statements/Conditional.cs
+++ b/NoHoPython/Compilation/Statements/Conditional.cs
@@ -2,6 +2,7 @@
 using NoHoPython.IntermediateRepresentation.Values;
 using NoHoPython.Scoping;
 using NoHoPython.Typing;
+using System.Diagnostics;
 using System.Text;
 
 namespace NoHoPython.IntermediateRepresentation.Values
@@ -26,7 +27,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if (Condition.IsTruey)
                 IRValue.EmitMemorySafe(IfTrueValue, irProgram, emitter, typeargs);
@@ -52,7 +53,11 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 {
     partial class CodeBlock
     {
-        public static void CIndent(StringBuilder emitter, int indent) => emitter.Append(new string('\t', indent));
+        public static void CIndent(StatementEmitter emitter, int indent)
+        {
+            Debug.Assert(indent >= 0);
+            emitter.Append(new string('\t', indent));
+        }
 
         public virtual void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -62,7 +67,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             Statements.ForEach((statement) => statement.ScopeForUsedTypes(typeargs, irBuilder));
         }
 
-        public void EmitInitialize(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void EmitInitialize(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (Statements == null)
                 throw new InvalidOperationException();
@@ -71,21 +76,17 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 declaration.EmitCDecl(irProgram, emitter, typeargs, indent);
         }
 
-        public void EmitNoOpen(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent, bool insertFinalBreak)
+        public void EmitNoOpen(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent, bool insertFinalBreak)
         {
             if (Statements == null)
                 throw new InvalidOperationException();
 
-            Statements.ForEach((statement) =>
-            {
-                if(irProgram.EmitLineDirectives)
-                {
-                    CodeBlock.CIndent(emitter, indent + 1);
-                    statement.ErrorReportedElement.SourceLocation.EmitLineDirective(emitter);
-                }
+            Statements.ForEach((statement) => {
+                emitter.LastSourceLocation = statement.ErrorReportedElement.SourceLocation;
                 statement.Emit(irProgram, emitter, typeargs, indent + 1);
             });
 
+            emitter.LastSourceLocation = BlockBeginLocation;
             if (!CodeBlockAllCodePathsReturn())
             {
                 foreach (Variable declaration in LocalVariables)
@@ -110,7 +111,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public virtual void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public virtual void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (Statements == null)
                 throw new InvalidOperationException();
@@ -137,7 +138,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (Condition.IsTruey && Condition.IsPure)
             {
@@ -179,7 +180,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (Condition.IsFalsey && Condition.IsPure)
                 return;
@@ -216,7 +217,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (Condition.IsFalsey && Condition.IsPure)
                 return;
@@ -243,7 +244,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             IterationBlock.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             emitter.AppendLine("{");
@@ -273,7 +274,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 handler.ToExecute.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             EnumType enumType = (EnumType)MatchValue.Type.SubstituteWithTypearg(typeargs);
 
@@ -298,7 +299,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                     CodeBlock.CIndent(emitter, indent + 1);
                     emitter.Append($"{currentOption.GetCName(irProgram)} {handler.MatchedVariable.GetStandardIdentifier()} = ");
 
-                    StringBuilder matchedOptionValue = new();
+                    BufferedEmitter matchedOptionValue = new();
                     IRValue.EmitMemorySafe(MatchValue.GetPostEvalPure(), irProgram, matchedOptionValue, typeargs);
                     matchedOptionValue.Append($".data.{currentOption.GetStandardIdentifier(irProgram)}_set");
 
@@ -326,13 +327,14 @@ namespace NoHoPython.IntermediateRepresentation.Statements
     {
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             foreach (Variable variable in activeLoopVariables)
                 if (variable.Type.SubstituteWithTypearg(typeargs).RequiresDisposal)
                 {
                     CodeBlock.CIndent(emitter, indent);
                     variable.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, variable.GetStandardIdentifier(), "NULL");
+                    emitter.AppendLine();
                 }
 
             CodeBlock.CIndent(emitter, indent);
@@ -345,7 +347,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
     partial class AssertStatement
     {
-        public static void EmitAsserter(StringBuilder emitter, bool doCallStack)
+        public static void EmitAsserter(StatementEmitter emitter, bool doCallStack)
         {
             emitter.AppendLine("void _nhp_assert(int flag, const char* src_loc, const char* assertion_src) {");
             emitter.AppendLine("\tif(!flag) {");
@@ -369,7 +371,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => Condition.ScopeForUsedTypes(typeargs, irBuilder);
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (irProgram.EliminateAsserts)
                 return;

--- a/NoHoPython/Compilation/Statements/EnumDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/EnumDeclaration.cs
@@ -36,7 +36,7 @@ namespace NoHoPython.IntermediateRepresentation
         private List<EnumType> usedEnumTypes;
         public readonly Dictionary<EnumDeclaration, List<EnumType>> EnumTypeOverloads;
 
-        public void ForwardDeclareEnumTypes(StringBuilder emitter)
+        public void ForwardDeclareEnumTypes(StatementEmitter emitter)
         {
             foreach (EnumType usedEnum in usedEnumTypes)
             {
@@ -58,7 +58,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void ForwardDeclareType(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclareType(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.EnumTypeOverloads.ContainsKey(this))
                 return;
@@ -67,7 +67,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 enumType.EmitCStruct(irProgram, emitter);
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.EnumTypeOverloads.ContainsKey(this))
                 return;
@@ -80,15 +80,15 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                     emitter.AppendLine($"{usedEnum.GetCName(irProgram)} change_resp_owner{usedEnum.GetStandardIdentifier(irProgram)}({usedEnum.GetCName(irProgram)} to_mutate, void* responsible_destroyer);");
                 if (usedEnum.RequiresDisposal)
                 {
-                    emitter.AppendLine($"void free_enum{usedEnum.GetStandardIdentifier(irProgram)}({usedEnum.GetCName(irProgram)} _nhp_enum);");
+                    emitter.AppendLine($"void free_enum{usedEnum.GetStandardIdentifier(irProgram)}({usedEnum.GetCName(irProgram)} _nhp_enum, void* child_agent);");
                     emitter.AppendLine($"{usedEnum.GetCName(irProgram)} copy_enum{usedEnum.GetStandardIdentifier(irProgram)}({usedEnum.GetCName(irProgram)} _nhp_enum, void* responsible_destroyer);");
                     if (!irProgram.EmitExpressionStatements)
-                        emitter.AppendLine($"{usedEnum.GetCName(irProgram)} move_enum{usedEnum.GetStandardIdentifier(irProgram)}({usedEnum.GetCName(irProgram)}* dest, {usedEnum.GetCName(irProgram)} src);");
+                        emitter.AppendLine($"{usedEnum.GetCName(irProgram)} move_enum{usedEnum.GetStandardIdentifier(irProgram)}({usedEnum.GetCName(irProgram)}* dest, {usedEnum.GetCName(irProgram)} src, void* child_agent);");
                 }
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (!irProgram.EnumTypeOverloads.ContainsKey(this))
                 return;
@@ -121,13 +121,13 @@ namespace NoHoPython.Typing
         public string GetStandardIdentifier(IRProgram irProgram) => $"_nhp_enum_{IScopeSymbol.GetAbsolouteName(EnumDeclaration)}_empty_option_{Name}";
         public string GetCName(IRProgram irProgram) => throw new CannotCompileEmptyTypeError(null);
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }
@@ -141,13 +141,13 @@ namespace NoHoPython.Typing
 
         public string GetCName(IRProgram irProgram) => EnumDeclaration.IsEmpty ? $"{GetStandardIdentifier(irProgram)}_options_t" : $"{GetStandardIdentifier(irProgram)}_t";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
         {
             if(RequiresDisposal)
-                emitter.AppendLine($"free_enum{GetStandardIdentifier(irProgram)}({valueCSource});");
+                emitter.Append($"free_enum{GetStandardIdentifier(irProgram)}({valueCSource}, {childAgent});");
         }
 
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
         {
             if (RequiresDisposal)
             {
@@ -160,24 +160,24 @@ namespace NoHoPython.Typing
                 emitter.Append(valueCSource);
         }
 
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (RequiresDisposal)
             {
                 if (irProgram.EmitExpressionStatements)
-                    IType.EmitMoveExpressionStatement(this, irProgram, emitter, destC, valueCSource);
+                    IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
                 else
-                    emitter.Append($"move_enum{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource})");
+                    emitter.Append($"move_enum{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
             }
             else
                 emitter.Append($"({destC} = {valueCSource})");
         }
 
-        public void EmitGetProperty(IRProgram irProgram, StringBuilder emitter, string valueCSource, Property property) => emitter.Append($"get_{property.Name}{GetStandardIdentifier(irProgram)}({valueCSource})");
+        public void EmitGetProperty(IRProgram irProgram, IEmitter emitter, string valueCSource, Property property) => emitter.Append($"get_{property.Name}{GetStandardIdentifier(irProgram)}({valueCSource})");
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(EnumDeclaration.IsEmpty ? valueCSource : $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})");
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(EnumDeclaration.IsEmpty ? valueCSource : $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})");
 
         public string GetCEnumOptionForType(IRProgram irProgram, IType type) => $"{GetStandardIdentifier(irProgram)}OPTION_{type.GetStandardIdentifier(irProgram)}";
 
@@ -190,7 +190,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this) || EnumDeclaration.IsEmpty)
                 return;
@@ -207,7 +207,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitOptionsCEnum(IRProgram irProgram, StringBuilder emitter)
+        public void EmitOptionsCEnum(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.AppendLine($"typedef enum {GetStandardIdentifier(irProgram)}_options {{");
             for(int i = 0; i < options.Value.Count; i++)
@@ -222,7 +222,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine($"{GetStandardIdentifier(irProgram)}_options_t;");
         }
 
-        public void EmitMarshallerHeaders(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMarshallerHeaders(IRProgram irProgram, StatementEmitter emitter)
         {
             if (EnumDeclaration.IsEmpty)
                 return;
@@ -236,13 +236,13 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitPropertyGetHeaders(IRProgram irProgram, StringBuilder emitter)
+        public void EmitPropertyGetHeaders(IRProgram irProgram, StatementEmitter emitter)
         {
             foreach (Property property in globalSupportedProperties[this].Value.Values)
                 emitter.AppendLine($"{property.Type.GetCName(irProgram)} get_{property.Name}{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum);");
         }
 
-        public void EmitMarshallers(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMarshallers(IRProgram irProgram, StatementEmitter emitter)
         {
             if (EnumDeclaration.IsEmpty)
                 return;
@@ -266,7 +266,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitPropertyGetters(IRProgram irProgram, StringBuilder emitter)
+        public void EmitPropertyGetters(IRProgram irProgram, StatementEmitter emitter)
         {
             foreach (Property property in globalSupportedProperties[this].Value.Values)
             {
@@ -285,23 +285,24 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitDestructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
         {
-            emitter.AppendLine($"void free_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum) {{");
+            emitter.AppendLine($"void free_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum, void* child_agent) {{");
             emitter.AppendLine("\tswitch(_nhp_enum.option) {");
             foreach(IType option in options.Value)
                 if (option.RequiresDisposal)
                 {
                     emitter.AppendLine($"\tcase {GetCEnumOptionForType(irProgram, option)}:");
                     emitter.Append("\t\t");
-                    option.EmitFreeValue(irProgram, emitter, $"_nhp_enum.data.{option.GetStandardIdentifier(irProgram)}_set", "NULL");
+                    option.EmitFreeValue(irProgram, emitter, $"_nhp_enum.data.{option.GetStandardIdentifier(irProgram)}_set", "child_agent");
+                    emitter.AppendLine();
                     emitter.AppendLine("\t\tbreak;");
                 }
             emitter.AppendLine("\t}");
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.Append($"{GetCName(irProgram)} copy_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} _nhp_enum");
 
@@ -328,20 +329,21 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitMover(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
 
-            emitter.AppendLine($"{GetCName(irProgram)} move_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src) {{");
+            emitter.AppendLine($"{GetCName(irProgram)} move_enum{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src, void* child_agent) {{");
             emitter.Append('\t');
-            EmitFreeValue(irProgram, emitter, "*dest", "NULL");
+            EmitFreeValue(irProgram, emitter, "*dest", "child_agent");
+            emitter.AppendLine();
             emitter.AppendLine($"\t*dest = src;");
             emitter.AppendLine("\treturn src;");
             emitter.AppendLine("}");
         }
 
-        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StringBuilder emitter)
+        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!MustSetResponsibleDestroyer)
                 return;
@@ -363,7 +365,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitOptionTypeNames(IRProgram irProgram, StringBuilder emitter)
+        public void EmitOptionTypeNames(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.NameRuntimeTypes)
                 return;
@@ -394,7 +396,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Value.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             EnumType realPrototype = (EnumType)TargetType.SubstituteWithTypearg(typeargs);
 
@@ -408,11 +410,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, emitter, typeargs, responsibleDestroyer);
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), responsibleDestroyer);
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), responsibleDestroyer);
                 emitter.Append(')');
             }
         }
@@ -428,7 +426,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             EnumValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if (!irProgram.EmitExpressionStatements)
                 throw new InvalidOperationException();
@@ -494,7 +492,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             EnumValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             EnumType enumType = (EnumType)EnumValue.Type.SubstituteWithTypearg(typeargs);
 

--- a/NoHoPython/Compilation/Statements/EnumDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/EnumDeclaration.cs
@@ -447,4 +447,26 @@ namespace NoHoPython.IntermediateRepresentation.Values
             irProgram.ExpressionDepth--;
         }
     }
+
+    partial class CheckEnumOption
+    {
+        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
+
+        public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
+        {
+            Option.SubstituteWithTypearg(typeargs).ScopeForUsedTypes(irBuilder);
+            EnumValue.ScopeForUsedTypes(typeargs, irBuilder);
+        }
+
+        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        {
+            EnumType enumType = (EnumType)EnumValue.Type.SubstituteWithTypearg(typeargs);
+
+            emitter.Append('(');
+            IRValue.EmitMemorySafe(EnumValue, irProgram, emitter, typeargs);
+            emitter.Append(".option == ");
+            emitter.Append(enumType.GetCEnumOptionForType(irProgram, Option.SubstituteWithTypearg(typeargs)));
+            emitter.Append(')');
+        }
+    }
 }

--- a/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
@@ -36,7 +36,7 @@ namespace NoHoPython.IntermediateRepresentation
         private List<InterfaceType> usedInterfaceTypes;
         public readonly Dictionary<InterfaceDeclaration, List<InterfaceType>> InterfaceTypeOverloads;
         
-        public void ForwardDeclareInterfaceTypes(StringBuilder emitter)
+        public void ForwardDeclareInterfaceTypes(StatementEmitter emitter)
         {
             foreach (InterfaceType usedInterface in usedInterfaceTypes)
                 emitter.AppendLine($"typedef struct {usedInterface.GetStandardIdentifier(this)} {usedInterface.GetCName(this)};");
@@ -50,7 +50,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
     {
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void ForwardDeclareType(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclareType(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.InterfaceTypeOverloads.ContainsKey(this))
                 return;
@@ -59,7 +59,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 interfaceType.EmitCStruct(irProgram, emitter);
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.InterfaceTypeOverloads.ContainsKey(this))
                 return;
@@ -67,15 +67,15 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             foreach (InterfaceType interfaceType in irProgram.InterfaceTypeOverloads[this])
             {
                 interfaceType.EmitMarshallerHeader(irProgram, emitter);
-                emitter.AppendLine($"void free_interface{interfaceType.GetStandardIdentifier(irProgram)}({interfaceType.GetCName(irProgram)} interface);");
+                emitter.AppendLine($"void free_interface{interfaceType.GetStandardIdentifier(irProgram)}({interfaceType.GetCName(irProgram)} interface, void* child_agent);");
                 emitter.AppendLine($"{interfaceType.GetCName(irProgram)} copy_interface{interfaceType.GetStandardIdentifier(irProgram)}({interfaceType.GetCName(irProgram)} interface, void* responsibleDestroyer);");
                 emitter.AppendLine($"{interfaceType.GetCName(irProgram)} change_resp_owner{interfaceType.GetStandardIdentifier(irProgram)}({interfaceType.GetCName(irProgram)} interface, void* responsibleDestroyer);");
                 if (!irProgram.EmitExpressionStatements)
-                    emitter.AppendLine($"{interfaceType.GetCName(irProgram)} move_interface{interfaceType.GetStandardIdentifier(irProgram)}({interfaceType.GetCName(irProgram)}* dest, {interfaceType.GetCName(irProgram)} src);");
+                    emitter.AppendLine($"{interfaceType.GetCName(irProgram)} move_interface{interfaceType.GetStandardIdentifier(irProgram)}({interfaceType.GetCName(irProgram)}* dest, {interfaceType.GetCName(irProgram)} src, void* child_agent);");
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (!irProgram.InterfaceTypeOverloads.ContainsKey(this))
                 return;
@@ -103,8 +103,8 @@ namespace NoHoPython.Typing
 
         public string GetCName(IRProgram irProgram) => $"{GetStandardIdentifier(irProgram)}_t";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => emitter.AppendLine($"free_interface{GetStandardIdentifier(irProgram)}({valueCSource});");
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => emitter.Append($"free_interface{GetStandardIdentifier(irProgram)}({valueCSource}, {childAgent});");
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
         {
             if(MustSetResponsibleDestroyer)
                 emitter.Append($"copy_interface{GetStandardIdentifier(irProgram)}({valueCSource}, {responsibleDestroyer})");
@@ -112,21 +112,21 @@ namespace NoHoPython.Typing
                 emitter.Append($"copy_interface{GetStandardIdentifier(irProgram)}({valueCSource})");
         }
 
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (irProgram.EmitExpressionStatements)
-                IType.EmitMoveExpressionStatement(this, irProgram, emitter, destC, valueCSource);
+                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
             else
-                emitter.Append($"move_interface{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource})");
+                emitter.Append($"move_interface{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(MustSetResponsibleDestroyer ? $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})" : valueCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(MustSetResponsibleDestroyer ? $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})" : valueCSource);
 
-        public void EmitGetProperty(IRProgram irProgram, StringBuilder emitter, string valueCSource, Property property) => emitter.Append($"{valueCSource}.{property.Name}");
+        public void EmitGetProperty(IRProgram irProgram, IEmitter emitter, string valueCSource, Property property) => emitter.Append($"{valueCSource}.{property.Name}");
 
-        public void EmitMarshallerHeader(IRProgram irProgram, StringBuilder emitter) => emitter.AppendLine($"{GetCName(irProgram)} marshal_interface{GetStandardIdentifier(irProgram)}({string.Join(", ", requiredImplementedProperties.Value.ConvertAll((prop) => $"{prop.Type.GetCName(irProgram)} {prop.Name}"))}{(MustSetResponsibleDestroyer ? ", void* responsibleDestroyer" : string.Empty)});");
+        public void EmitMarshallerHeader(IRProgram irProgram, StatementEmitter emitter) => emitter.AppendLine($"{GetCName(irProgram)} marshal_interface{GetStandardIdentifier(irProgram)}({string.Join(", ", requiredImplementedProperties.Value.ConvertAll((prop) => $"{prop.Type.GetCName(irProgram)} {prop.Name}"))}{(MustSetResponsibleDestroyer ? ", void* responsibleDestroyer" : string.Empty)});");
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -137,7 +137,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this))
                 return;
@@ -148,7 +148,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitMarshaller(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMarshaller(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.Append($"{GetCName(irProgram)} marshal_interface{GetStandardIdentifier(irProgram)}({string.Join(", ", requiredImplementedProperties.Value.ConvertAll((prop) => $"{prop.Type.GetCName(irProgram)} {prop.Name}"))}");
 
@@ -167,20 +167,21 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitDestructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
         {
-            emitter.AppendLine($"void free_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} interface) {{");
+            emitter.AppendLine($"void free_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} interface, void* child_agent) {{");
 
             foreach (var property in requiredImplementedProperties.Value)
                 if (property.Type.RequiresDisposal)
                 {
                     emitter.Append('\t');
-                    property.Type.EmitFreeValue(irProgram, emitter, $"interface.{property.Name}", "NULL");
+                    property.Type.EmitFreeValue(irProgram, emitter, $"interface.{property.Name}", "child_agent");
+                    emitter.AppendLine();
                 }
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.Append($"{GetCName(irProgram)} copy_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} interface");
 
@@ -199,20 +200,21 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitMover(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
 
-            emitter.AppendLine($"{GetCName(irProgram)} move_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src) {{");
+            emitter.AppendLine($"{GetCName(irProgram)} move_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src, void* child_agent) {{");
             emitter.Append('\t');
-            EmitFreeValue(irProgram, emitter, "*dest", "NULL");
+            EmitFreeValue(irProgram, emitter, "*dest", "child_agent");
+            emitter.AppendLine();
             emitter.AppendLine($"\t*dest = src;");
             emitter.AppendLine("\treturn src;");
             emitter.AppendLine("}");
         }
 
-        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StringBuilder emitter)
+        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!MustSetResponsibleDestroyer)
                 return;
@@ -243,7 +245,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Value.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             InterfaceType realPrototype = (InterfaceType)TargetType.SubstituteWithTypearg(typeargs);
 
@@ -262,21 +264,18 @@ namespace NoHoPython.IntermediateRepresentation.Values
             bool firstEmit = true;
             foreach (Property property in properties)
             {
-                StringBuilder valueEmitter = new();
+                string valueEmitter;
                 if (Value.RequiresDisposal(typeargs))
-                    valueEmitter.Append("_nhp_marshal_buf");
+                    valueEmitter = "_nhp_marshal_buf";
+                else if (firstEmit)
+                    valueEmitter = BufferedEmitter.EmittedBufferedMemorySafe(Value, irProgram, typeargs);
                 else
                 {
-                    if (firstEmit)
-                        IRValue.EmitMemorySafe(Value, irProgram, valueEmitter, typeargs);
-                    else
-                    {
-                        IRValue.EmitMemorySafe(Value.GetPostEvalPure(), irProgram, valueEmitter, typeargs);
-                        firstEmit = false;
-                    }
+                    valueEmitter = BufferedEmitter.EmittedBufferedMemorySafe(Value.GetPostEvalPure(), irProgram, typeargs);
+                    firstEmit = false;
                 }
 
-                StringBuilder getPropertyEmitter = new();
+                BufferedEmitter getPropertyEmitter = new();
                 if (Value.Type.SubstituteWithTypearg(typeargs) is IPropertyContainer propertyContainer)
                     propertyContainer.EmitGetProperty(irProgram, getPropertyEmitter, valueEmitter.ToString(), property);
                 else

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -77,11 +77,11 @@ namespace NoHoPython.IntermediateRepresentation
         private List<ProcedureReference> usedProcedureReferences;
         public readonly Dictionary<ProcedureDeclaration, List<ProcedureReference>> ProcedureOverloads;
 
-        public void EmitAnonProcedureTypedefs(StringBuilder emitter)
+        public void EmitAnonProcedureTypedefs(StatementEmitter emitter)
         {
-            static void EmitProcTypedef(IRProgram irProgram, StringBuilder emitter, Tuple<ProcedureType, string> procedureInfo)
+            static void EmitProcTypedef(IRProgram irProgram, StatementEmitter emitter, Tuple<ProcedureType, string> procedureInfo)
             {
-                static void emitType(IRProgram irProgram, StringBuilder emitter, IType type)
+                static void emitType(IRProgram irProgram, StatementEmitter emitter, IType type)
                 {
                     if (type is RecordType ||
                        type is ProcedureType ||
@@ -129,27 +129,28 @@ namespace NoHoPython.IntermediateRepresentation
             }
         }
 
-        public void ForwardDeclareAnonProcedureTypes(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclareAnonProcedureTypes(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
 
             foreach (var uniqueProcedure in uniqueProcedureTypes)
             {
-                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src);");
+                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src, void* child_agent);");
             }
         }
 
-        public void EmitAnonProcedureMovers(IRProgram irProgram, StringBuilder emitter)
+        public void EmitAnonProcedureMovers(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
 
             foreach (var uniqueProcedure in uniqueProcedureTypes)
             {
-                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src) {{");
+                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src, void* child_agent) {{");
                 emitter.Append('\t');
-                uniqueProcedure.Item1.EmitFreeValue(this, emitter, "*dest", "NULL");
+                uniqueProcedure.Item1.EmitFreeValue(this, emitter, "*dest", "child_agent");
+                emitter.AppendLine();
                 emitter.AppendLine("\t*dest = src;");
                 emitter.AppendLine("\treturn src;");
                 emitter.AppendLine("}");
@@ -164,7 +165,7 @@ namespace NoHoPython.IntermediateRepresentation
             throw new InvalidOperationException();
         }
 
-        public void EmitAnonProcedureCapturedContecies(StringBuilder emitter)
+        public void EmitAnonProcedureCapturedContecies(StatementEmitter emitter)
         {
             foreach (ProcedureReference procedureReference in usedProcedureReferences)
             {
@@ -182,7 +183,7 @@ namespace NoHoPython.IntermediateRepresentation
 {
     partial interface IRValue
     {
-        public static void EmitMemorySafe(IRValue value, IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeArgs)
+        public static void EmitMemorySafe(IRValue value, IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeArgs)
         {
             if (value.RequiresDisposal(typeArgs))
                 throw new CannotEmitDestructorError(value);
@@ -202,22 +203,22 @@ namespace NoHoPython.Typing
 
         public string GetCName(IRProgram irProgram) => $"{GetStandardIdentifier(irProgram)}_info_t*";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => emitter.AppendLine($"({valueCSource})->_nhp_destructor({valueCSource});"); 
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"({valueCSource})->_nhp_copier({valueCSource}, {responsibleDestroyer})");
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => emitter.Append($"({valueCSource})->_nhp_destructor({valueCSource});"); 
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"({valueCSource})->_nhp_copier({valueCSource}, {responsibleDestroyer})");
         
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (irProgram.EmitExpressionStatements)
-                IType.EmitMoveExpressionStatement(this, irProgram, emitter, destC, valueCSource);
+                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
             else
-                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource})");
+                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => emitter.Append($"({valueCSource})->_nhp_record_copier({valueCSource}, {recordCSource})");
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append($"({valueCSource})->_nhp_resp_mutator({valueCSource}, {newResponsibleDestroyer})");
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => emitter.Append($"({valueCSource})->_nhp_record_copier({valueCSource}, {recordCSource})");
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append($"({valueCSource})->_nhp_resp_mutator({valueCSource}, {newResponsibleDestroyer})");
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -260,7 +261,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             scoping = false; 
         }
 
-        public void ForwardDeclareActual(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclareActual(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.ProcedureOverloads.ContainsKey(this))
                 return;
@@ -269,17 +270,16 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 procedureReference.ForwardDeclare(irProgram, emitter);
         }
 
-        public override void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
+        public override void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
 
-        public void EmitActual(IRProgram irProgram, StringBuilder emitter, int indent)
+        public void EmitActual(IRProgram irProgram, StatementEmitter emitter, int indent)
         {
             if (!irProgram.ProcedureOverloads.ContainsKey(this))
                 return;
 
             foreach (ProcedureReference procedureReference in irProgram.ProcedureOverloads[this])
             {
-                if (irProgram.EmitLineDirectives)
-                    ErrorReportedElement.SourceLocation.EmitLineDirective(emitter);
+                emitter.LastSourceLocation = ErrorReportedElement.SourceLocation;
                 Dictionary<TypeParameter, IType> typeargs = procedureReference.Emit(irProgram, emitter);
                 EmitInitialize(irProgram, emitter, typeargs, indent);
                 EmitNoOpen(irProgram, emitter, typeargs, indent, false);
@@ -309,7 +309,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             irBuilder.DeclareUsedProcedureReference(this);
         }
 
-        private void EmitCFunctionHeader(IRProgram irProgram, StringBuilder emitter)
+        private void EmitCFunctionHeader(IRProgram irProgram, StatementEmitter emitter)
         {
 #pragma warning disable CS8604 // Parameters not null when compilation begins
             emitter.Append($"{ReturnType.GetCName(irProgram)} {GetStandardIdentifier(irProgram)}(");
@@ -337,7 +337,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 #pragma warning restore CS8604 
         }
 
-        public void EmitCaptureCFunctionHeader(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCaptureCFunctionHeader(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.Append($"{anonProcedureType.GetCName(irProgram)} capture_{GetStandardIdentifier(irProgram)}(");
             foreach (Variable capturedVariable in ProcedureDeclaration.CapturedVariables)
@@ -345,7 +345,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.Append("void* responsible_destroyer)");
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
         {
             if(IsAnonymous)
                 emitter.AppendLine($"typedef struct {GetStandardIdentifier(irProgram)}_captured {GetClosureCaptureCType(irProgram)};");
@@ -358,7 +358,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public Dictionary<TypeParameter, IType> Emit(IRProgram irProgram, StringBuilder emitter)
+        public Dictionary<TypeParameter, IType> Emit(IRProgram irProgram, StatementEmitter emitter)
         {
             EmitCFunctionHeader(irProgram, emitter);
             emitter.AppendLine(" {");
@@ -372,7 +372,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             return typeArguments;
         }
 
-        public void EmitCaptureContextCStruct(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCaptureContextCStruct(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!IsAnonymous)
                 return;
@@ -390,7 +390,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.AppendLine("};");
         }
 
-        public void EmitAnonymizer(IRProgram irProgram, StringBuilder emitter)
+        public void EmitAnonymizer(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!IsAnonymous)
                 return;
@@ -417,7 +417,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.AppendLine("}");
         }
 
-        public void EmitAnonDestructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitAnonDestructor(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!IsAnonymous)
                 return;
@@ -434,13 +434,14 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 {
                     emitter.Append('\t');
                     capturedVariable.Type.SubstituteWithTypearg(typeArguments).EmitFreeValue(irProgram, emitter, $"to_free->{capturedVariable.GetStandardIdentifier()}", "to_free->_nhp_child_agent");
+                    emitter.AppendLine();
                 }
 
             emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("to_free", $"sizeof({GetStandardIdentifier(irProgram)}_captured_t)")};");
             emitter.AppendLine("}");
         }
 
-        public void EmitAnonCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitAnonCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!IsAnonymous)
                 return;
@@ -454,7 +455,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.AppendLine("}");
         }
 
-        public void EmitAnonRecordCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitAnonRecordCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!IsAnonymous)
                 return;
@@ -471,7 +472,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.AppendLine("}");
         }
 
-        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StringBuilder emitter)
+        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!IsAnonymous)
                 return;
@@ -505,7 +506,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             ToReturn.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             Variable? localToReturn = null;
             if (ToReturn.Type is not NothingType)
@@ -521,11 +522,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 else if (ToReturn.RequiresDisposal(typeargs))
                     ToReturn.Emit(irProgram, emitter, typeargs, "NULL");
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    ToReturn.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    ToReturn.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), "NULL");
-                }
+                    ToReturn.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(ToReturn, irProgram, typeargs, "NULL"), "NULL");
 
                 emitter.AppendLine(";");
             }
@@ -535,6 +532,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 {
                     CodeBlock.CIndent(emitter, indent);
                     variable.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, variable.GetStandardIdentifier(), "NULL");
+                    emitter.AppendLine();
                 }
 
             CodeBlock.CIndent(emitter, indent);
@@ -556,7 +554,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             emitter.AppendLine("{");
@@ -579,6 +577,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
                 CodeBlock.CIndent(emitter, indent + 1);
                 AbortMessage.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, "_nhp_abort_msg", "NULL");
+                emitter.AppendLine();
             }
             else
                 emitter.Append("puts(\"AbortError: No message given.\");");
@@ -595,7 +594,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
     {
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
     }
 }
 
@@ -611,13 +610,13 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Arguments.ForEach((arg) => arg.ScopeForUsedTypes(typeargs, irBuilder));
         }
 
-        public abstract void EmitCall(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer);
+        public abstract void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer);
 
-        private void EmitCallWithResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        private void EmitCallWithResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
         {
             if (assignResponsibleDestroyer && responsibleDestroyer != "NULL")
             {
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 EmitCall(irProgram, valueBuilder, typeargs, bufferedArguments, currentNestedCall, responsibleDestroyer);
                 Type.SubstituteWithTypearg(typeargs).EmitMutateResponsibleDestroyer(irProgram, emitter, valueBuilder.ToString(), responsibleDestroyer);
             }
@@ -625,7 +624,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 EmitCall(irProgram, emitter, typeargs, bufferedArguments, currentNestedCall, responsibleDestroyer);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             irProgram.ExpressionDepth++;
             if (irProgram.DoCallStack)
@@ -633,7 +632,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (!irProgram.EmitExpressionStatements)
                     throw new CannotPerformCallStackReporting(this);
                 emitter.Append("({");
-                CallStackReporting.EmitReportCall(emitter, ErrorReportedElement, -1);
+                CallStackReporting.EmitReportCall(emitter, ErrorReportedElement);
                 emitter.Append($"{Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} _nhp_callrep_res{irProgram.ExpressionDepth} = ");
             }
 
@@ -651,7 +650,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     {
                         emitter.Append($"{Arguments[i].Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} _nhp_argbuf_{i}{irProgram.ExpressionDepth} = ");
                         Arguments[i].Emit(irProgram, emitter, typeargs, "NULL");
-                        emitter.AppendLine(";");
+                        emitter.Append(";");
                         bufferedArguments.Add(i);
                     }
                 emitter.Append($"{Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} _nhp_res{irProgram.ExpressionDepth} = ");
@@ -669,14 +668,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if (irProgram.DoCallStack)
             {
                 emitter.Append(';');
-                CallStackReporting.EmitReportReturn(emitter, -1);
+                CallStackReporting.EmitReportReturn(emitter);
                 emitter.Append($"_nhp_callrep_res{irProgram.ExpressionDepth};}})");
             }
 
             irProgram.ExpressionDepth--;
         }
 
-        protected void EmitArguments(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall)
+        protected void EmitArguments(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall)
         {
             bool argbufNonConstArgs = !Arguments.TrueForAll((arg) => arg.IsPure);
             int constArgs = Arguments.Where(x => x.IsConstant && x.IsPure).Count();
@@ -700,7 +699,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             void emitAndDestroyCall(SortedSet<int> bufferedArguments, int indent)
             {
@@ -713,6 +712,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     emitter.AppendLine(";");
                     CodeBlock.CIndent(emitter, indent + 1);
                     Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, "_nhp_callrep_res0", "NULL");
+                    emitter.AppendLine();
                     CodeBlock.CIndent(emitter, indent);
                     emitter.AppendLine("}");
                 }
@@ -751,6 +751,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     {
                         CodeBlock.CIndent(emitter, indent + 1);
                         Arguments[i].Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, $"_nhp_argbuf_{i}0", "NULL");
+                        emitter.AppendLine();
                     }
                 CodeBlock.CIndent(emitter, indent);
                 emitter.AppendLine("}");
@@ -771,7 +772,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             base.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public override void EmitCall(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
         {
             emitter.Append($"{Procedure.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(");
             EmitArguments(irProgram, emitter, typeargs, bufferedArguments, currentNestedCall);
@@ -794,7 +795,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             base.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public override void EmitCall(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
         {
             if (!ProcedureValue.IsPure)
                 throw new CannotEnsureOrderOfEvaluation(this);
@@ -815,7 +816,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => Procedure.SubstituteWithTypearg(typeargs).ScopeForUsedTypes(irBuilder);
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             emitter.Append($"capture_{Procedure.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}({string.Join("", Procedure.SubstituteWithTypearg(typeargs).ProcedureDeclaration.CapturedVariables.ConvertAll((capturedVar) => $"{((capturedVar.IsRecordSelf && parentProcedure == null) ? "_nhp_self" : capturedVar.GetStandardIdentifier())}, "))}{responsibleDestroyer})");
         }
@@ -828,7 +829,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             base.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public override void EmitCall(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
         {
             emitter.Append($"{ForeignCProcedure.Name}(");
             EmitArguments(irProgram, emitter, typeargs, bufferedArguments, currentNestedCall);

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -278,6 +278,8 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
             foreach (ProcedureReference procedureReference in irProgram.ProcedureOverloads[this])
             {
+                if (irProgram.EmitLineDirectives)
+                    ErrorReportedElement.SourceLocation.EmitLineDirective(emitter);
                 Dictionary<TypeParameter, IType> typeargs = procedureReference.Emit(irProgram, emitter);
                 EmitInitialize(irProgram, emitter, typeargs, indent);
                 EmitNoOpen(irProgram, emitter, typeargs, indent, false);

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -177,7 +177,6 @@ namespace NoHoPython.Typing
     {
         public bool RequiresDisposal => true;
         public bool MustSetResponsibleDestroyer => true;
-        public bool ContainsRecords => false;
 
         public string GetStandardIdentifier(IRProgram irProgram) => irProgram.GetAnonProcedureStandardIdentifier(this);
 
@@ -197,7 +196,6 @@ namespace NoHoPython.Typing
         public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
         public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => emitter.Append($"({valueCSource})->_nhp_record_copier({valueCSource}, {recordCSource})");
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append($"({valueCSource})->_nhp_resp_mutator({valueCSource}, {newResponsibleDestroyer})");
-        public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new InvalidOperationException();
 
         public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
 

--- a/NoHoPython/Compilation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/RecordDeclaration.cs
@@ -36,7 +36,7 @@ namespace NoHoPython.IntermediateRepresentation
         private List<RecordType> usedRecordTypes;
         public readonly Dictionary<RecordDeclaration, List<RecordType>> RecordTypeOverloads;
 
-        public void ForwardDeclareRecordTypes(StringBuilder emitter)
+        public void ForwardDeclareRecordTypes(StatementEmitter emitter)
         {
             foreach (RecordType recordType in usedRecordTypes)
                 emitter.AppendLine($"typedef struct {recordType.GetStandardIdentifier(this)} {recordType.GetStandardIdentifier(this)}_t;");
@@ -48,17 +48,18 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 {
     partial class RecordDeclaration
     {
-        public static void EmitRecordMaskProto(StringBuilder emitter)
+        public static void EmitRecordMaskProto(StatementEmitter emitter)
         {
             emitter.AppendLine("typedef struct _nhp_std_record_mask _nhp_std_record_mask_t;");
             emitter.AppendLine("struct _nhp_std_record_mask {");
             emitter.AppendLine("\tint _nhp_ref_count;");
+            emitter.AppendLine("\tint _nhp_master_count;");
             emitter.AppendLine("\tint _nhp_lock;");
-            emitter.AppendLine("\t_nhp_std_record_mask_t* parent_record;");
+            emitter.AppendLine($"\t{RecordType.StandardRecordMask} parent_record;");
             emitter.AppendLine("} _nhp_std_record_mask;");
         }
 
-        public static void EmitRecordChildFinder(StringBuilder emitter)
+        public static void EmitRecordChildFinder(StatementEmitter emitter)
         {
             emitter.AppendLine("int _nhp_record_has_child(_nhp_std_record_mask_t* parent, _nhp_std_record_mask_t* child) {");
             emitter.AppendLine("\twhile(child != NULL) {");
@@ -72,7 +73,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void ForwardDeclareType(IRProgram irProgram, StringBuilder emitter) 
+        public void ForwardDeclareType(IRProgram irProgram, StatementEmitter emitter) 
         {
             if (!irProgram.RecordTypeOverloads.ContainsKey(this))
                 return;
@@ -81,7 +82,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 recordType.EmitCStruct(irProgram, emitter);
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StringBuilder emitter)
+        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.RecordTypeOverloads.ContainsKey(this))
                 return;
@@ -98,11 +99,11 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 if (!recordType.HasCopier)
                     emitter.AppendLine($"{recordType.GetCName(irProgram)} copy_record{recordType.GetStandardIdentifier(irProgram)}({recordType.GetCName(irProgram)} record, {RecordType.StandardRecordMask} parent_record);");
                 if (!irProgram.EmitExpressionStatements)
-                    emitter.AppendLine($"{recordType.GetCName(irProgram)} move_record{recordType.GetStandardIdentifier(irProgram)}({recordType.GetCName(irProgram)}* dest, {recordType.GetCName(irProgram)} src);");
+                    emitter.AppendLine($"{recordType.GetCName(irProgram)} move_record{recordType.GetStandardIdentifier(irProgram)}({recordType.GetCName(irProgram)}* dest, {recordType.GetCName(irProgram)} src, void* child_agent);");
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             if (!irProgram.RecordTypeOverloads.ContainsKey(this))
                 return;
@@ -137,9 +138,9 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram) => $"{GetStandardIdentifier(irProgram)}_t*";
         public string GetCHeapSizer(IRProgram irProgram) => $"sizeof({GetStandardIdentifier(irProgram)}_t)";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => emitter.AppendLine($"free_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){childAgent});");
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => emitter.Append($"free_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){childAgent});");
 
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
         {
             if (HasCopier)
             {
@@ -151,20 +152,20 @@ namespace NoHoPython.Typing
                 emitter.Append($"copy_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){responsibleDestroyer})");
         }
 
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (irProgram.EmitExpressionStatements)
-                IType.EmitMoveExpressionStatement(this, irProgram, emitter, destC, valueCSource);
+                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
             else
-                emitter.Append($"move_record(&{destC}, {valueCSource})");
+                emitter.Append($"move_record(&{destC}, {valueCSource}, {childAgent})");
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"borrow_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({RecordType.StandardRecordMask}){responsibleDestroyer})");
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"borrow_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){responsibleDestroyer})");
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
 
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append($"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){newResponsibleDestroyer})");
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append($"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){newResponsibleDestroyer})");
 
-        public void EmitGetProperty(IRProgram irProgram, StringBuilder emitter, string valueCSource, Property property) => emitter.Append($"{valueCSource}->{property.Name}");
+        public void EmitGetProperty(IRProgram irProgram, IEmitter emitter, string valueCSource, Property property) => emitter.Append($"{valueCSource}->{property.Name}");
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -177,13 +178,14 @@ namespace NoHoPython.Typing
                 }
         }
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this))
                 return;
 
             emitter.AppendLine("struct " + GetStandardIdentifier(irProgram) + " {");
             emitter.AppendLine("\tint _nhp_ref_count;");
+            emitter.AppendLine("\tint _nhp_master_count;");
             emitter.AppendLine("\tint _nhp_lock;");
             emitter.AppendLine($"\t{StandardRecordMask} parent_record;");
             foreach (var property in properties.Value)
@@ -191,7 +193,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitConstructorCHeader(IRProgram irProgram, StringBuilder emitter)
+        public void EmitConstructorCHeader(IRProgram irProgram, StatementEmitter emitter)
         {
             ProcedureType constructorType = (ProcedureType)FindProperty("__init__").Type;
 
@@ -201,7 +203,7 @@ namespace NoHoPython.Typing
             emitter.Append($"{StandardRecordMask} parent_record)");
         }
 
-        public void EmitConstructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitConstructor(IRProgram irProgram, StatementEmitter emitter)
         {
             ProcedureType constructorType = (ProcedureType)FindProperty("__init__").Type;
             EmitConstructorCHeader(irProgram, emitter);
@@ -209,6 +211,7 @@ namespace NoHoPython.Typing
             
             emitter.AppendLine($"\t{GetCName(irProgram)} _nhp_self = {irProgram.MemoryAnalyzer.Allocate(GetCHeapSizer(irProgram))};");
             emitter.AppendLine("\t_nhp_self->_nhp_ref_count = 0;");
+            emitter.AppendLine("\t_nhp_self->_nhp_master_count = 0;");
             emitter.AppendLine("\t_nhp_self->_nhp_lock = 0;");
             emitter.AppendLine("\t_nhp_self->parent_record = parent_record;");
             
@@ -219,11 +222,7 @@ namespace NoHoPython.Typing
                     if (recordProperty.DefaultValue.RequiresDisposal(new Dictionary<TypeParameter, IType>()))
                         recordProperty.DefaultValue.Emit(irProgram, emitter, new Dictionary<TypeParameter, IType>(), "_nhp_self");
                     else
-                    {
-                        StringBuilder valueBuilder = new();
-                        recordProperty.DefaultValue.Emit(irProgram, valueBuilder, new Dictionary<TypeParameter, IType>(), "NULL");
-                        recordProperty.Type.EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), "_nhp_self");
-                    }
+                        recordProperty.Type.EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(recordProperty.DefaultValue, irProgram, new(), "NULL"), "_nhp_self");
                     emitter.AppendLine(";");
                 }
 
@@ -236,35 +235,42 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitDestructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.AppendLine($"void free_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} record, {StandardRecordMask} child_agent) {{");
 
-            emitter.AppendLine($"\tif(record->_nhp_lock || _nhp_record_has_child(({RecordType.StandardRecordMask})record, child_agent))");
+            emitter.AppendLine($"\tif(record->_nhp_lock || _nhp_record_has_child(({StandardRecordMask})record, child_agent))");
             emitter.AppendLine("\t\treturn;");
 
+
             emitter.AppendLine("\tif(record->_nhp_ref_count) {");
+            emitter.AppendLine($"\t\tif(_nhp_record_has_child(child_agent, ({StandardRecordMask})record)) {{");
+            emitter.AppendLine("\t\t\tif(record->_nhp_master_count == 0)");
+            emitter.AppendLine("\t\t\t\trecord->parent_record = NULL;");
+            emitter.AppendLine("\t\t\telse");
+            emitter.AppendLine("\t\t\t\trecord->_nhp_master_count--;");
+            emitter.AppendLine("\t\t}");
             emitter.AppendLine("\t\trecord->_nhp_ref_count--;");
             emitter.AppendLine("\t\treturn;");
             emitter.AppendLine("\t}");
+            
             emitter.AppendLine("\trecord->_nhp_lock = 1;");
-
             if (HasDestructor)
                 emitter.AppendLine("\trecord->__del__->_nhp_this_anon(record->__del__);");
-
             foreach (RecordDeclaration.RecordProperty recordProperty in properties.Value)
             {
                 if (recordProperty.Type.RequiresDisposal)
                 {
                     emitter.Append('\t');
-                    recordProperty.Type.EmitFreeValue(irProgram, emitter, $"record->{recordProperty.Name}", "NULL");
+                    recordProperty.Type.EmitFreeValue(irProgram, emitter, $"record->{recordProperty.Name}", "record");
+                    emitter.AppendLine();
                 }
             }
             emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("record", GetCHeapSizer(irProgram))};");
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             if (HasCopier)
                 return;
@@ -272,6 +278,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine($"{GetCName(irProgram)} copy_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} record, {StandardRecordMask} parent_record) {{");
             emitter.AppendLine($"\t{GetCName(irProgram)} copied_record = {irProgram.MemoryAnalyzer.Allocate(GetCHeapSizer(irProgram))};");
             emitter.AppendLine("\tcopied_record->_nhp_ref_count = 0;");
+            emitter.AppendLine("\tcopied_record->_nhp_master_count = 0;");
             emitter.AppendLine("\tcopied_record->_nhp_lock = 0;");
             emitter.AppendLine("\tcopied_record->parent_record = parent_record;");
 
@@ -286,29 +293,35 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitMover(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
 
-            emitter.AppendLine($"{GetCName(irProgram)} move_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src) {{");
+            emitter.AppendLine($"{GetCName(irProgram)} move_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src, void* child_agent) {{");
             emitter.Append('\t');
-            EmitFreeValue(irProgram, emitter, "*dest", "NULL");
+            EmitFreeValue(irProgram, emitter, "*dest", "child_agent");
+            emitter.AppendLine();
             emitter.AppendLine("\t*dest = src;");
             emitter.AppendLine("\treturn src;");
             emitter.AppendLine("}");
         }
 
-        public void EmitBorrower(IRProgram irProgram, StringBuilder emitter)
+        public void EmitBorrower(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.AppendLine($"{GetCName(irProgram)} borrow_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} record, void* responsible_destroyer) {{");
-            emitter.AppendLine($"\tif(!_nhp_record_has_child(({StandardRecordMask})record, responsible_destroyer))");
+
+            emitter.AppendLine($"\tif(!_nhp_record_has_child(({StandardRecordMask})record, responsible_destroyer)) {{");
             emitter.AppendLine("\t\trecord->_nhp_ref_count++;");
+            emitter.AppendLine($"\t\tif(_nhp_record_has_child(({StandardRecordMask})responsible_destroyer, ({StandardRecordMask})record))");
+            emitter.AppendLine("\t\t\trecord->_nhp_master_count++;");
+            emitter.AppendLine("\t}");
+            
             emitter.AppendLine("\treturn record;");
             emitter.AppendLine("}");
         }
 
-        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StringBuilder emitter)
+        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.AppendLine($"{GetCName(irProgram)} change_resp_owner{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} record, {StandardRecordMask} parent_record) {{");
             emitter.AppendLine("\trecord->parent_record = parent_record;");

--- a/NoHoPython/Compilation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/RecordDeclaration.cs
@@ -148,7 +148,7 @@ namespace NoHoPython.Typing
                 EmitMutateResponsibleDestroyer(irProgram, emitter, valueBuilder.ToString(), responsibleDestroyer);
             }
             else
-                emitter.Append($"copy_record{GetStandardIdentifier(irProgram)}({valueCSource}, {responsibleDestroyer})");
+                emitter.Append($"copy_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){responsibleDestroyer})");
         }
 
         public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)

--- a/NoHoPython/Compilation/Types/Arrays.cs
+++ b/NoHoPython/Compilation/Types/Arrays.cs
@@ -28,19 +28,19 @@ namespace NoHoPython.IntermediateRepresentation
     {
         private List<ArrayType> usedArrayTypes;
 
-        public void EmitArrayTypeTypedefs(StringBuilder emitter)
+        public void EmitArrayTypeTypedefs(StatementEmitter emitter)
         {
             foreach (ArrayType arrayType in usedArrayTypes)
                 emitter.AppendLine($"typedef struct {arrayType.GetStandardIdentifier(this)} {arrayType.GetCName(this)};");
         }
 
-        public void EmitArrayTypeCStructs(StringBuilder emitter)
+        public void EmitArrayTypeCStructs(StatementEmitter emitter)
         {
             foreach (ArrayType arrayType in usedArrayTypes)
                 arrayType.EmitCStruct(this, emitter);
         }
 
-        public void ForwardDeclareArrayTypes(StringBuilder emitter)
+        public void ForwardDeclareArrayTypes(StatementEmitter emitter)
         {
             foreach (ArrayType arrayType in usedArrayTypes)
             {
@@ -58,7 +58,7 @@ namespace NoHoPython.IntermediateRepresentation
                     emitter.AppendLine($"{arrayType.GetCName(this)} change_resp_owner{arrayType.GetStandardIdentifier(this)}({arrayType.GetCName(this)} array, void* responsible_destroyer);");
 
                 if (!EmitExpressionStatements)
-                    emitter.AppendLine($"{arrayType.GetCName(this)} move{arrayType.GetStandardIdentifier(this)}({arrayType.GetCName(this)}* src, {arrayType.GetCName(this)} dest);");
+                    emitter.AppendLine($"{arrayType.GetCName(this)} move{arrayType.GetStandardIdentifier(this)}({arrayType.GetCName(this)}* src, {arrayType.GetCName(this)} dest, void* child_agent);");
 
                 if (arrayType.ElementType.RequiresDisposal)
                 {
@@ -71,7 +71,7 @@ namespace NoHoPython.IntermediateRepresentation
             }
         }
 
-        public void EmitArrayTypeMarshallers(StringBuilder emitter, bool doCallStack)
+        public void EmitArrayTypeMarshallers(StatementEmitter emitter, bool doCallStack)
         {
             if (DoBoundsChecking)
             {
@@ -116,15 +116,15 @@ namespace NoHoPython.Typing
         public bool RequiresDisposal => true;
         public bool MustSetResponsibleDestroyer => ElementType.MustSetResponsibleDestroyer;
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
         {
             if (ElementType.RequiresDisposal)
-                emitter.AppendLine($"free{GetStandardIdentifier(irProgram)}({valueCSource});");
+                emitter.Append($"free{GetStandardIdentifier(irProgram)}({valueCSource});");
             else
-                emitter.AppendLine($"{irProgram.MemoryAnalyzer.Dealloc($"{valueCSource}.buffer", $"{valueCSource}.length * sizeof({ElementType.GetCName(irProgram)})")};");
+                emitter.Append($"{irProgram.MemoryAnalyzer.Dealloc($"{valueCSource}.buffer", $"{valueCSource}.length * sizeof({ElementType.GetCName(irProgram)})")};");
         }
 
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
         {
             if (ElementType.RequiresDisposal)
                 emitter.Append($"copy{GetStandardIdentifier(irProgram)}({valueCSource}");
@@ -137,18 +137,18 @@ namespace NoHoPython.Typing
             emitter.Append(')');
         }
 
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
             if (irProgram.EmitExpressionStatements)
-                IType.EmitMoveExpressionStatement(this, irProgram, emitter, destC, valueCSource);
+                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
             else
-                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource})");
+                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
 
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(MustSetResponsibleDestroyer ? $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})" : valueCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(MustSetResponsibleDestroyer ? $"change_resp_owner{GetStandardIdentifier(irProgram)}({valueCSource}, {newResponsibleDestroyer})" : valueCSource);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) => irBuilder.ScopeForUsedArrayType(this);
 
@@ -156,7 +156,7 @@ namespace NoHoPython.Typing
 
         public string GetStandardIdentifier(IRProgram irProgram) => $"_nhp_array_{ElementType.GetStandardIdentifier(irProgram)}";
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this))
                 return;
@@ -171,7 +171,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitMarshaller(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMarshaller(IRProgram irProgram, StatementEmitter emitter)
         {
             emitter.Append($"{GetCName(irProgram)} marshal{GetStandardIdentifier(irProgram)}({ElementType.GetCName(irProgram)}* buffer, int length");
 
@@ -232,6 +232,7 @@ namespace NoHoPython.Typing
             {
                 emitter.Append('\t');
                 ElementType.EmitFreeValue(irProgram, emitter, "proto", "NULL");
+                emitter.AppendLine();
             }
 
             if(MustSetResponsibleDestroyer)
@@ -242,7 +243,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitDestructor(IRProgram irProgram, StringBuilder emitter)
+        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!ElementType.RequiresDisposal)
                 return;
@@ -250,13 +251,14 @@ namespace NoHoPython.Typing
             emitter.AppendLine($"void free{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} to_free) {{");
             emitter.AppendLine("\tfor(int i = 0; i < to_free.length; i++) {");
             emitter.Append("\t\t");
-            ElementType.EmitFreeValue(irProgram, emitter, "to_free.buffer[i]", "NULL");
+            ElementType.EmitFreeValue(irProgram, emitter, "to_free.buffer[i]", "to_free.responsible_destroyer");
+            emitter.AppendLine();
             emitter.AppendLine("\t}");
             emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("to_free.buffer", $"to_free.length * sizeof({ElementType.GetCName(irProgram)})")};");
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StringBuilder emitter)
+        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!ElementType.RequiresDisposal)
                 return;
@@ -285,20 +287,21 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitMover(IRProgram irProgram, StringBuilder emitter)
+        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
         {
             if (irProgram.EmitExpressionStatements)
                 return;
 
-            emitter.AppendLine($"{GetCName(irProgram)} move{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src) {{");
+            emitter.AppendLine($"{GetCName(irProgram)} move{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src, void* child_agent) {{");
             emitter.Append('\t');
-            EmitFreeValue(irProgram, emitter, "(*dest)", "NULL");
+            EmitFreeValue(irProgram, emitter, "(*dest)", "child_agent");
+            emitter.AppendLine();
             emitter.AppendLine("\t*dest = src;");
             emitter.AppendLine("\treturn src;");
             emitter.AppendLine("}");
         }
 
-        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StringBuilder emitter)
+        public void EmitResponsibleDestroyerMutator(IRProgram irProgram, StatementEmitter emitter)
         {
             if (!MustSetResponsibleDestroyer)
                 return;

--- a/NoHoPython/Compilation/Types/BasicTypes.cs
+++ b/NoHoPython/Compilation/Types/BasicTypes.cs
@@ -1,17 +1,16 @@
 ﻿using NoHoPython.IntermediateRepresentation;
-using System.Diagnostics;
-using System.Text;
 
 namespace NoHoPython.Typing
 {
     partial interface IType
     {
-        public static void EmitMoveExpressionStatement(IType type, IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource)
+        public static void EmitMove(IType type, IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
         {
-            Debug.Assert(irProgram.EmitExpressionStatements);
-
+            if (!irProgram.EmitExpressionStatements)
+                throw new CannotEmitDestructorError(null);
+            
             emitter.Append($"({{{type.GetCName(irProgram)} _nhp_es_move_temp = {destC}; {destC} = {valueCSource}; ");
-            type.EmitFreeValue(irProgram, emitter, "_nhp_es_move_temp", "NULL");
+            type.EmitFreeValue(irProgram, emitter, "_nhp_es_move_temp", childAgent);
             emitter.Append($" {destC};}})");
         }
     }
@@ -25,15 +24,15 @@ namespace NoHoPython.Typing
         public abstract string GetCName(IRProgram irProgram);
         public string GetStandardIdentifier(IRProgram irProgram) => TypeName;
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) { }
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => emitter.Append(valueCSource);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => emitter.Append($"({destC} = {valueCSource})");
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) { }
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append(valueCSource);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => emitter.Append($"({destC} = {valueCSource})");
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
 
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(valueCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(valueCSource);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }
@@ -72,13 +71,13 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram) => "void";
         public string GetStandardIdentifier(IRProgram irProgram) => "nothing";
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }

--- a/NoHoPython/Compilation/Types/BasicTypes.cs
+++ b/NoHoPython/Compilation/Types/BasicTypes.cs
@@ -21,7 +21,6 @@ namespace NoHoPython.Typing
         public bool IsNativeCType => true;
         public bool RequiresDisposal => false;
         public bool MustSetResponsibleDestroyer => false;
-        public bool ContainsRecords => false;
 
         public abstract string GetCName(IRProgram irProgram);
         public string GetStandardIdentifier(IRProgram irProgram) => TypeName;
@@ -35,7 +34,6 @@ namespace NoHoPython.Typing
         public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
 
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => emitter.Append(valueCSource);
-        public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new InvalidOperationException();
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }
     }
@@ -70,7 +68,6 @@ namespace NoHoPython.Typing
         public bool IsNativeCType => true;
         public bool RequiresDisposal => false;
         public bool MustSetResponsibleDestroyer => false;
-        public bool ContainsRecords => false;
 
         public string GetCName(IRProgram irProgram) => "void";
         public string GetStandardIdentifier(IRProgram irProgram) => "nothing";
@@ -81,7 +78,6 @@ namespace NoHoPython.Typing
         public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
         public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new CannotCompileEmptyTypeError(null);
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new CannotCompileEmptyTypeError(null);
-        public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new InvalidOperationException();
         public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) { }

--- a/NoHoPython/Compilation/Types/TypeParameters.cs
+++ b/NoHoPython/Compilation/Types/TypeParameters.cs
@@ -8,7 +8,6 @@ namespace NoHoPython.Typing
         public bool IsNativeCType => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public bool RequiresDisposal => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public bool MustSetResponsibleDestroyer => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public bool ContainsRecords => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
         public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
 
@@ -23,7 +22,6 @@ namespace NoHoPython.Typing
         public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) => throw new UnexpectedTypeParameterError(TypeParameter, null);
     }
 }

--- a/NoHoPython/Compilation/Types/TypeParameters.cs
+++ b/NoHoPython/Compilation/Types/TypeParameters.cs
@@ -14,14 +14,14 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public string GetStandardIdentifier(IRProgram irProgram) => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) => throw new UnexpectedTypeParameterError(TypeParameter, null);
     }
 }

--- a/NoHoPython/Compilation/Values/Arithmetic.cs
+++ b/NoHoPython/Compilation/Values/Arithmetic.cs
@@ -13,7 +13,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Input.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             void EmitCCast(string castTo)
             {
@@ -53,7 +53,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class ArithmeticOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             if (Operation == ArithmeticOperation.Exponentiate)
             {
@@ -100,7 +100,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             ArrayValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             void EmitOp()
             {

--- a/NoHoPython/Compilation/Values/InterpolatedString.cs
+++ b/NoHoPython/Compilation/Values/InterpolatedString.cs
@@ -6,21 +6,21 @@ namespace NoHoPython.Typing
 {
     partial interface IType
     {
-        public string GetFormatSpecifier();
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource);
+        public string GetFormatSpecifier(IRProgram irProgram);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource);
     }
 
     partial class Primitive
     {
-        public abstract string GetFormatSpecifier();
-        public virtual void EmitFormatValue(StringBuilder emitter, string valueCSource) => emitter.Append(valueCSource);
+        public abstract string GetFormatSpecifier(IRProgram irProgram);
+        public virtual void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => emitter.Append(valueCSource);
     }
 
     partial class ArrayType
     {
-        public string GetFormatSpecifier() => ElementType.IsCompatibleWith(Primitive.Character) ? "%.*s" : "%p";
+        public string GetFormatSpecifier(IRProgram irProgram) => ElementType.IsCompatibleWith(Primitive.Character) ? "%.*s" : "%p";
 
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource)
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource)
         {
             if (!ElementType.IsCompatibleWith(Primitive.Character))
                 emitter.Append("(void*)");
@@ -37,71 +37,71 @@ namespace NoHoPython.Typing
 
     partial class BooleanType
     {
-        public override string GetFormatSpecifier() => "%s";
+        public override string GetFormatSpecifier(IRProgram irProgram) => "%s";
 
-        public override void EmitFormatValue(StringBuilder emitter, string valueCSource) => emitter.Append($"(({valueCSource}) ? \"true\" : \"false\")");
+        public override void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => emitter.Append($"(({valueCSource}) ? \"true\" : \"false\")");
     }
 
     partial class CharacterType
     {
-        public override string GetFormatSpecifier() => "%c";
+        public override string GetFormatSpecifier(IRProgram irProgram) => "%c";
     }
 
     partial class IntegerType
     {
-        public override string GetFormatSpecifier() => "%li";
+        public override string GetFormatSpecifier(IRProgram irProgram) => "%li";
     }
 
     partial class DecimalType
     {
-        public override string GetFormatSpecifier() => "%lf";
+        public override string GetFormatSpecifier(IRProgram irProgram) => "%lf";
     }
 
     partial class HandleType
     {
-        public override string GetFormatSpecifier() => "%p";
+        public override string GetFormatSpecifier(IRProgram irProgram) => "%p";
     }
 
     partial class EmptyEnumOption
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class EnumType
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => irProgram.NameRuntimeTypes ? "%s" : throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => emitter.Append(irProgram.NameRuntimeTypes ? $"{GetStandardIdentifier(irProgram)}_typenames[(int){valueCSource}.option]" : throw new InvalidOperationException());
     }
 
     partial class RecordType
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class InterfaceType
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class ProcedureType
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class NothingType
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
     }
 
     partial class TypeParameterReference
     {
-        public string GetFormatSpecifier() => throw new NoFormatSpecifierForType(this);
-        public void EmitFormatValue(StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
+        public string GetFormatSpecifier(IRProgram irProgram) => throw new NoFormatSpecifierForType(this);
+        public void EmitFormatValue(IRProgram irProgram, StringBuilder emitter, string valueCSource) => throw new InvalidOperationException();
     }
 }
 
@@ -134,12 +134,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 {
                     emitter.Append(", ");
                     if (bufferedArguments.Contains(i))
-                        arguments[i].Type.EmitFormatValue(emitter, $"intpd_buffered_arg{i}{irProgram.ExpressionDepth}");
+                        arguments[i].Type.EmitFormatValue(irProgram, emitter, $"intpd_buffered_arg{i}{irProgram.ExpressionDepth}");
                     else
                     {
                         StringBuilder valueBuilder = new();
                         arguments[i].Emit(irProgram, valueBuilder, typeargs, "NULL");
-                        arguments[i].Type.EmitFormatValue(emitter, valueBuilder.ToString());
+                        arguments[i].Type.EmitFormatValue(irProgram, emitter, valueBuilder.ToString());
                     }
                 }
             }
@@ -151,7 +151,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     if (!irValue.IsPure || irValue.RequiresDisposal(typeargs))
                         bufferedArguments.Add(arguments.Count);
 
-                    formatBuilder.Append(irValue.Type.GetFormatSpecifier());
+                    formatBuilder.Append(irValue.Type.GetFormatSpecifier(irProgram));
                     arguments.Add(irValue);
                 }
                 else

--- a/NoHoPython/Compilation/Values/Literals.cs
+++ b/NoHoPython/Compilation/Values/Literals.cs
@@ -208,7 +208,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             EmitArguments(irProgram, emitter, typeargs, releasedArguments, currentNestedCall);
             if (Arguments.Count > 0)
                 emitter.Append(", ");
-            emitter.Append($"{responsibleDestroyer})");
+            emitter.Append($"(_nhp_std_record_mask_t*){responsibleDestroyer})");
         }
     }
 }

--- a/NoHoPython/Compilation/Values/Operators.cs
+++ b/NoHoPython/Compilation/Values/Operators.cs
@@ -17,10 +17,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
-            StringBuilder leftBuilder = new();
-            StringBuilder rightBuilder = new();
+            BufferedEmitter leftBuilder = new();
+            BufferedEmitter rightBuilder = new();
 
             if((!ShortCircuit && (!Left.IsPure && !Right.IsConstant) || (!Right.IsPure && !Left.IsConstant))
                 || Left.RequiresDisposal(typeargs) || Right.RequiresDisposal(typeargs))
@@ -54,12 +54,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
             } 
         }
 
-        public abstract void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource);
+        public abstract void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource);
     }
 
     partial class ComparativeOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             emitter.Append($"({leftCSource}");
             switch (Operation)
@@ -89,7 +89,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class LogicalOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             emitter.Append($"({leftCSource} ");
             switch (Operation)
@@ -107,7 +107,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class BitwiseOperator
     {
-        public override void EmitExpression(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
         {
             emitter.Append($"({leftCSource} ");
             switch (Operation)
@@ -143,7 +143,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if ((!Array.IsPure && !Index.IsConstant) ||
                 (!Index.IsPure && !Array.IsConstant))
@@ -196,7 +196,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if ((!Array.IsPure && (!Index.IsConstant || !Value.IsConstant)) ||
                (!Index.IsPure && (!Array.IsConstant || !Value.IsConstant)) ||
@@ -217,24 +217,20 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     IRValue.EmitMemorySafe(Index, irProgram, emitter, typeargs);
 
                 emitter.Append(';');
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, valueBuilder, typeargs, $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
                 else
-                {
-                    StringBuilder toCopyBuilder = new();
-                    Value.Emit(irProgram, toCopyBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, toCopyBuilder.ToString(), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
 
-                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"arr{irProgram.ExpressionDepth}.buffer[ind{irProgram.ExpressionDepth}]", valueBuilder.ToString());
+                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"arr{irProgram.ExpressionDepth}.buffer[ind{irProgram.ExpressionDepth}]", valueBuilder.ToString(), $"arr{irProgram.ExpressionDepth}.responsible_destroyer");
                 emitter.Append(";})");
 
                 irProgram.ExpressionDepth--;
             }
             else
             {
-                StringBuilder destBuilder = new();
+                BufferedEmitter destBuilder = new();
                 IRValue.EmitMemorySafe(Array, irProgram, destBuilder, typeargs);
                 if (irProgram.DoBoundsChecking)
                 {
@@ -249,25 +245,21 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     destBuilder.Append(']');
                 }
 
-                StringBuilder arrayResponsibleDestructor = new();
+                BufferedEmitter arrayResponsibleDestructor = new();
                 IRValue.EmitMemorySafe(Array.GetPostEvalPure(), irProgram, arrayResponsibleDestructor, typeargs);
                 arrayResponsibleDestructor.Append(".responsible_destroyer");
 
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, valueBuilder, typeargs, arrayResponsibleDestructor.ToString());
                 else
-                {
-                    StringBuilder toCopyBuilder = new();
-                    Value.Emit(irProgram, toCopyBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, toCopyBuilder.ToString(), arrayResponsibleDestructor.ToString());
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), arrayResponsibleDestructor.ToString());
 
-                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, destBuilder.ToString(), valueBuilder.ToString());
+                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, destBuilder.ToString(), valueBuilder.ToString(), arrayResponsibleDestructor.ToString());
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
 
@@ -290,18 +282,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     IRValue.EmitMemorySafe(Index, irProgram, emitter, typeargs);
                 emitter.AppendLine(";");
 
-                StringBuilder valueBuilder = new();
+                BufferedEmitter valueBuilder = new();
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, valueBuilder, typeargs, "arr.responsible_destroyer");
                 else
-                {
-                    StringBuilder toCopyBuilder = new();
-                    Value.Emit(irProgram, toCopyBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, toCopyBuilder.ToString(), "arr.responsible_destroyer");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, valueBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), "arr.responsible_destroyer");
 
                 CodeBlock.CIndent(emitter, indent + 1);
-                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, "arr.buffer[ind]", valueBuilder.ToString());
+                Value.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, "arr.buffer[ind]", valueBuilder.ToString(), "arr.responsible_destroyer");
                 emitter.AppendLine(";");
                 CodeBlock.CIndent(emitter, indent);
                 emitter.AppendLine("}");
@@ -324,13 +312,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
-            StringBuilder valueBuilder = new();
-            IRValue.EmitMemorySafe(Record, irProgram, valueBuilder, typeargs);
-
             if (Record.Type.SubstituteWithTypearg(typeargs) is IPropertyContainer propertyContainer)
-                propertyContainer.EmitGetProperty(irProgram, emitter, valueBuilder.ToString(), Property);
+                propertyContainer.EmitGetProperty(irProgram, emitter, BufferedEmitter.EmittedBufferedMemorySafe(Record, irProgram, typeargs), Property);
             else
                 throw new UnexpectedTypeException(Record.Type.SubstituteWithTypearg(typeargs), ErrorReportedElement);
         }
@@ -347,7 +332,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
+        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer)
         {
             if ((!Record.IsPure && !Value.IsConstant) || (!Value.IsPure && !Record.IsConstant))
             {
@@ -360,18 +345,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, emitter, typeargs, $"record{irProgram.ExpressionDepth}");
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), $"record{irProgram.ExpressionDepth}");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), $"record{irProgram.ExpressionDepth}");
 
                 emitter.Append(';');
                 if (IsInitializingProperty)
                     emitter.Append($"(record{irProgram.ExpressionDepth}->{Property.Name} = value{irProgram.ExpressionDepth});}})");
                 else
                 {
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record{irProgram.ExpressionDepth}->{Property.Name}", $"value{irProgram.ExpressionDepth}");
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record{irProgram.ExpressionDepth}->{Property.Name}", $"value{irProgram.ExpressionDepth}", $"record{irProgram.ExpressionDepth}");
                     emitter.Append(";})");
                 }
                 
@@ -379,42 +360,31 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
             else
             {
-                StringBuilder recordBuilder = new();
-                IRValue.EmitMemorySafe(Record, irProgram, recordBuilder, typeargs);
-
-                StringBuilder recordResponsibleDestroyer = new();
-                IRValue.EmitMemorySafe(Record.GetPostEvalPure(), irProgram, recordResponsibleDestroyer, typeargs);
+                string recordCSource = BufferedEmitter.EmittedBufferedMemorySafe(Record, irProgram, typeargs);
+                string recordResponsibleDestroyer = BufferedEmitter.EmittedBufferedMemorySafe(Record.GetPostEvalPure(), irProgram, typeargs);
 
                 if (IsInitializingProperty)
                 {
-                    emitter.Append($"({recordBuilder}->{Property.Name} = ");
+                    emitter.Append($"({recordCSource}->{Property.Name} = ");
                     if (Value.RequiresDisposal(typeargs))
-                        Value.Emit(irProgram, emitter, typeargs, recordResponsibleDestroyer.ToString());
+                        Value.Emit(irProgram, emitter, typeargs, recordResponsibleDestroyer);
                     else
-                    {
-                        StringBuilder valueBuilder = new();
-                        Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), recordResponsibleDestroyer.ToString());
-                    }
+                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), recordResponsibleDestroyer.ToString());
                     emitter.Append(')');
                 }
                 else
                 {
-                    StringBuilder toCopyBuilder = new();
+                    BufferedEmitter toCopyBuilder = new();
                     if (Value.RequiresDisposal(typeargs))
                         Value.Emit(irProgram, toCopyBuilder, typeargs, recordResponsibleDestroyer.ToString());
                     else
-                    {
-                        StringBuilder valueBuilder = new();
-                        Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, toCopyBuilder, valueBuilder.ToString(), recordResponsibleDestroyer.ToString());
-                    }
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"{recordBuilder}->{Property.Name}", toCopyBuilder.ToString());
+                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, toCopyBuilder, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), recordResponsibleDestroyer.ToString());
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"{recordCSource}->{Property.Name}", toCopyBuilder.ToString(), recordCSource);
                 }
             }
         }
 
-        public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
         {
             CodeBlock.CIndent(emitter, indent);
             if ((!Record.IsPure && !Value.IsConstant) || (!Value.IsPure && !Record.IsConstant))
@@ -431,11 +401,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (Value.RequiresDisposal(typeargs))
                     Value.Emit(irProgram, emitter, typeargs, "record");
                 else
-                {
-                    StringBuilder valueBuilder = new();
-                    Value.Emit(irProgram, valueBuilder, typeargs, "NULL");
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valueBuilder.ToString(), "record");
-                }
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), "record");
                 emitter.AppendLine(";");
 
                 CodeBlock.CIndent(emitter, indent + 1);
@@ -443,7 +409,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     emitter.AppendLine($"record->{Property.Name} = value;");
                 else
                 {
-                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record->{Property.Name}", "value");
+                    Property.Type.SubstituteWithTypearg(typeargs).EmitMoveValue(irProgram, emitter, $"record->{Property.Name}", "value", "record");
                     emitter.AppendLine(";");
                 }
                 CodeBlock.CIndent(emitter, indent);
@@ -462,7 +428,7 @@ namespace NoHoPython.Typing
 {
     partial class ArrayType
     {
-        public static void EmitBoundsCheckedIndex(IRProgram irProgram, StringBuilder emitter, Dictionary<TypeParameter, IType> typeargs, IRValue array, IRValue index, Syntax.IAstElement errorReportedElement)
+        public static void EmitBoundsCheckedIndex(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, IRValue array, IRValue index, Syntax.IAstElement errorReportedElement)
         {
             emitter.Append("_nhp_bounds_check(");
             IRValue.EmitMemorySafe(index, irProgram, emitter, typeargs);

--- a/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
@@ -254,6 +254,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public IRValue GetPostEvalPure() => new UnwrapEnumValue(EnumValue.GetPostEvalPure(), Type, ErrorReportedElement);
     }
 
+    partial class CheckEnumOption
+    {
+        public bool IsPure => EnumValue.IsPure;
+        public bool IsConstant => EnumValue.IsConstant;
+
+        public IRValue GetPostEvalPure() => new CheckEnumOption(EnumValue.GetPostEvalPure(), Type, ErrorReportedElement);
+    }
+
     partial class MarshalIntoInterface
     {
         public bool IsPure => Value.IsPure;

--- a/NoHoPython/IntermediateRepresentation/Analysis/InitializationAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/InitializationAnalysis.cs
@@ -327,6 +327,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => EnumValue.AnalyzePropertyInitialization(initializedProperties, recordDeclaration);
     }
 
+    partial class CheckEnumOption
+    {
+        public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => EnumValue.AnalyzePropertyInitialization(initializedProperties, recordDeclaration);
+    }
+
     partial class MarshalIntoInterface
     {
         public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => Value.AnalyzePropertyInitialization(initializedProperties, recordDeclaration);

--- a/NoHoPython/IntermediateRepresentation/Analysis/TypeParameterUsageAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/TypeParameterUsageAnalysis.cs
@@ -1,0 +1,63 @@
+﻿using NoHoPython.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NoHoPython.Typing
+{
+    partial interface IType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder);
+    }
+
+    partial class Primitive
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) { }
+    }
+
+    partial class ArrayType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) => ElementType.ScopeForUsedTypeParameters(irBuilder);
+    }
+
+    partial class ProcedureType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder)
+        {
+            ParameterTypes.ForEach((parameter) => parameter.ScopeForUsedTypeParameters(irBuilder));
+            ReturnType.ScopeForUsedTypeParameters(irBuilder);
+        }
+    }
+
+    partial class RecordType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) => TypeArguments.ForEach((typearg) => typearg.ScopeForUsedTypeParameters(irBuilder));
+    }
+
+    partial class InterfaceType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) => TypeArguments.ForEach((typearg) => typearg.ScopeForUsedTypeParameters(irBuilder));
+    }
+
+    partial class EnumType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) => TypeArguments.ForEach((typearg) => typearg.ScopeForUsedTypeParameters(irBuilder));
+    }
+
+    partial class TypeParameterReference
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) => irBuilder.ScopedProcedures.Peek().SanitizeTypeParameter(TypeParameter);
+    }
+
+    partial class EmptyEnumOption
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) { }
+    }
+
+    partial class NothingType
+    {
+        public void ScopeForUsedTypeParameters(AstIRProgramBuilder irBuilder) { }
+    }
+}

--- a/NoHoPython/IntermediateRepresentation/IntermediateRepresentation.cs
+++ b/NoHoPython/IntermediateRepresentation/IntermediateRepresentation.cs
@@ -63,7 +63,7 @@ namespace NoHoPython.Syntax
         public void AddEnumDeclaration(EnumDeclaration enumDeclaration) => EnumDeclarations.Add(enumDeclaration);
         public void AddProcDeclaration(ProcedureDeclaration procedureDeclaration) => ProcedureDeclarations.Add(procedureDeclaration);
 
-        public IRProgram ToIRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, MemoryAnalyzer memoryAnalyzer)
+        public IRProgram ToIRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, bool nameRuntimeTypes, MemoryAnalyzer memoryAnalyzer)
         {
             List<ProcedureDeclaration> compileHeads = new();
             foreach (ProcedureDeclaration procedureDeclaration in ProcedureDeclarations)
@@ -73,7 +73,7 @@ namespace NoHoPython.Syntax
                 procedureDeclaration.ScopeAsCompileHead(this);
             ScopeForAllSecondaryProcedures();
 
-            return new(doBoundsChecking, eliminateAsserts, emitExpressionStatements, doCallStack,
+            return new(doBoundsChecking, eliminateAsserts, emitExpressionStatements, doCallStack, nameRuntimeTypes,
                 RecordDeclarations, InterfaceDeclarations, EnumDeclarations, ProcedureDeclarations, new List<string>()
                 {
                     "<stdio.h>",
@@ -130,6 +130,7 @@ namespace NoHoPython.IntermediateRepresentation
         public bool EliminateAsserts { get; private set; }
         public bool EmitExpressionStatements { get; private set; }
         public bool DoCallStack { get; private set; }
+        public bool NameRuntimeTypes { get; private set; }
 
         private Dictionary<IType, HashSet<IType>> typeDependencyTree;
         private HashSet<IType> compiledTypes;
@@ -138,12 +139,13 @@ namespace NoHoPython.IntermediateRepresentation
 
         public int ExpressionDepth;
 
-        public IRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, List<RecordDeclaration> recordDeclarations, List<InterfaceDeclaration> interfaceDeclarations, List<EnumDeclaration> enumDeclarations, List<ProcedureDeclaration> procedureDeclarations, List<string> includedCFiles, List<ArrayType> usedArrayTypes, List<Tuple<ProcedureType, string>> uniqueProcedureTypes, List<ProcedureReference> usedProcedureReferences, Dictionary<ProcedureDeclaration, List<ProcedureReference>> procedureOverloads, List<EnumType> usedEnumTypes, Dictionary<EnumDeclaration, List<EnumType>> enumTypeOverloads, List<InterfaceType> usedInterfaceTypes, Dictionary<InterfaceDeclaration, List<InterfaceType>> interfaceTypeOverload, List<RecordType> usedRecordTypes, Dictionary<RecordDeclaration, List<RecordType>> recordTypeOverloads, Dictionary<IType, HashSet<IType>> typeDependencyTree, MemoryAnalyzer memoryAnalyzer)
+        public IRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, bool nameRuntimeTypes, List<RecordDeclaration> recordDeclarations, List<InterfaceDeclaration> interfaceDeclarations, List<EnumDeclaration> enumDeclarations, List<ProcedureDeclaration> procedureDeclarations, List<string> includedCFiles, List<ArrayType> usedArrayTypes, List<Tuple<ProcedureType, string>> uniqueProcedureTypes, List<ProcedureReference> usedProcedureReferences, Dictionary<ProcedureDeclaration, List<ProcedureReference>> procedureOverloads, List<EnumType> usedEnumTypes, Dictionary<EnumDeclaration, List<EnumType>> enumTypeOverloads, List<InterfaceType> usedInterfaceTypes, Dictionary<InterfaceDeclaration, List<InterfaceType>> interfaceTypeOverload, List<RecordType> usedRecordTypes, Dictionary<RecordDeclaration, List<RecordType>> recordTypeOverloads, Dictionary<IType, HashSet<IType>> typeDependencyTree, MemoryAnalyzer memoryAnalyzer)
         {
             DoBoundsChecking = doBoundsChecking;
             EliminateAsserts = eliminateAsserts;
             EmitExpressionStatements = emitExpressionStatements;
             DoCallStack = doCallStack;
+            NameRuntimeTypes = nameRuntimeTypes;
 
             RecordDeclarations = recordDeclarations;
             InterfaceDeclarations = interfaceDeclarations;

--- a/NoHoPython/IntermediateRepresentation/IntermediateRepresentation.cs
+++ b/NoHoPython/IntermediateRepresentation/IntermediateRepresentation.cs
@@ -229,6 +229,7 @@ namespace NoHoPython.IntermediateRepresentation
 
             //emit c structs
             RecordDeclaration.EmitRecordMaskProto(headerEmitter);
+            RecordDeclaration.EmitRecordChildFinder(headerEmitter);
             EmitArrayTypeCStructs(headerEmitter);
             EnumDeclarations.ForEach((enumDecl) => enumDecl.ForwardDeclareType(this, headerEmitter));
             InterfaceDeclarations.ForEach((interfaceDecl) => interfaceDecl.ForwardDeclareType(this, headerEmitter));

--- a/NoHoPython/IntermediateRepresentation/IntermediateRepresentation.cs
+++ b/NoHoPython/IntermediateRepresentation/IntermediateRepresentation.cs
@@ -63,7 +63,7 @@ namespace NoHoPython.Syntax
         public void AddEnumDeclaration(EnumDeclaration enumDeclaration) => EnumDeclarations.Add(enumDeclaration);
         public void AddProcDeclaration(ProcedureDeclaration procedureDeclaration) => ProcedureDeclarations.Add(procedureDeclaration);
 
-        public IRProgram ToIRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, bool nameRuntimeTypes, MemoryAnalyzer memoryAnalyzer)
+        public IRProgram ToIRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, bool nameRuntimeTypes, bool emitLineDirectives, MemoryAnalyzer memoryAnalyzer)
         {
             List<ProcedureDeclaration> compileHeads = new();
             foreach (ProcedureDeclaration procedureDeclaration in ProcedureDeclarations)
@@ -73,7 +73,7 @@ namespace NoHoPython.Syntax
                 procedureDeclaration.ScopeAsCompileHead(this);
             ScopeForAllSecondaryProcedures();
 
-            return new(doBoundsChecking, eliminateAsserts, emitExpressionStatements, doCallStack, nameRuntimeTypes,
+            return new(doBoundsChecking, eliminateAsserts, emitExpressionStatements, doCallStack, nameRuntimeTypes, emitLineDirectives,
                 RecordDeclarations, InterfaceDeclarations, EnumDeclarations, ProcedureDeclarations, new List<string>()
                 {
                     "<stdio.h>",
@@ -131,6 +131,7 @@ namespace NoHoPython.IntermediateRepresentation
         public bool EmitExpressionStatements { get; private set; }
         public bool DoCallStack { get; private set; }
         public bool NameRuntimeTypes { get; private set; }
+        public bool EmitLineDirectives { get;private set; } 
 
         private Dictionary<IType, HashSet<IType>> typeDependencyTree;
         private HashSet<IType> compiledTypes;
@@ -139,13 +140,14 @@ namespace NoHoPython.IntermediateRepresentation
 
         public int ExpressionDepth;
 
-        public IRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, bool nameRuntimeTypes, List<RecordDeclaration> recordDeclarations, List<InterfaceDeclaration> interfaceDeclarations, List<EnumDeclaration> enumDeclarations, List<ProcedureDeclaration> procedureDeclarations, List<string> includedCFiles, List<ArrayType> usedArrayTypes, List<Tuple<ProcedureType, string>> uniqueProcedureTypes, List<ProcedureReference> usedProcedureReferences, Dictionary<ProcedureDeclaration, List<ProcedureReference>> procedureOverloads, List<EnumType> usedEnumTypes, Dictionary<EnumDeclaration, List<EnumType>> enumTypeOverloads, List<InterfaceType> usedInterfaceTypes, Dictionary<InterfaceDeclaration, List<InterfaceType>> interfaceTypeOverload, List<RecordType> usedRecordTypes, Dictionary<RecordDeclaration, List<RecordType>> recordTypeOverloads, Dictionary<IType, HashSet<IType>> typeDependencyTree, MemoryAnalyzer memoryAnalyzer)
+        public IRProgram(bool doBoundsChecking, bool eliminateAsserts, bool emitExpressionStatements, bool doCallStack, bool nameRuntimeTypes, bool emitLineDirectives, List<RecordDeclaration> recordDeclarations, List<InterfaceDeclaration> interfaceDeclarations, List<EnumDeclaration> enumDeclarations, List<ProcedureDeclaration> procedureDeclarations, List<string> includedCFiles, List<ArrayType> usedArrayTypes, List<Tuple<ProcedureType, string>> uniqueProcedureTypes, List<ProcedureReference> usedProcedureReferences, Dictionary<ProcedureDeclaration, List<ProcedureReference>> procedureOverloads, List<EnumType> usedEnumTypes, Dictionary<EnumDeclaration, List<EnumType>> enumTypeOverloads, List<InterfaceType> usedInterfaceTypes, Dictionary<InterfaceDeclaration, List<InterfaceType>> interfaceTypeOverload, List<RecordType> usedRecordTypes, Dictionary<RecordDeclaration, List<RecordType>> recordTypeOverloads, Dictionary<IType, HashSet<IType>> typeDependencyTree, MemoryAnalyzer memoryAnalyzer)
         {
             DoBoundsChecking = doBoundsChecking;
             EliminateAsserts = eliminateAsserts;
             EmitExpressionStatements = emitExpressionStatements;
             DoCallStack = doCallStack;
             NameRuntimeTypes = nameRuntimeTypes;
+            EmitLineDirectives = emitLineDirectives;
 
             RecordDeclarations = recordDeclarations;
             InterfaceDeclarations = interfaceDeclarations;

--- a/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
@@ -21,15 +21,17 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         private List<VariableDeclaration> DeclaredVariables;
 
         public bool IsLoop { get; private set; }
-
         public int? BreakLabelId { get; private set; }
 
-        public CodeBlock(SymbolContainer parent, bool isLoop) : base(parent)
+        public SourceLocation BlockBeginLocation { get; private set; }
+
+        public CodeBlock(SymbolContainer parent, bool isLoop, SourceLocation blockBeginLocation) : base(parent)
         {
+            IsLoop = isLoop;
+            BlockBeginLocation = blockBeginLocation;
             Statements = null;
             LocalVariables = new List<Variable>();
             DeclaredVariables = new List<VariableDeclaration>();
-            IsLoop = isLoop;
         }
 
         public void AddVariableDeclaration(VariableDeclaration variableDeclaration)

--- a/NoHoPython/IntermediateRepresentation/Statements/Conditional.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Conditional.cs
@@ -205,13 +205,13 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, IfTrueBlock);
             irBuilder.SymbolMarshaller.GoBack();
 
             if (NextIf != null)
             {
-                scopedNextIf = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+                scopedNextIf = irBuilder.SymbolMarshaller.NewCodeBlock(false, NextIf.SourceLocation);
                 NextIf.ForwardDeclare(irBuilder);
                 irBuilder.SymbolMarshaller.GoBack();
             }
@@ -250,7 +250,7 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedToExecute = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+            scopedToExecute = irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, ToExecute);
             irBuilder.SymbolMarshaller.GoBack();
         }
@@ -274,7 +274,7 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true);
+            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, ToExecute);
             irBuilder.SymbolMarshaller.GoBack();
         }
@@ -299,7 +299,7 @@ namespace NoHoPython.Syntax.Statements
 
         public void ForwardDeclare(AstIRProgramBuilder irBuilder)
         {
-            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true);
+            scopedCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(true, SourceLocation);
             IAstStatement.ForwardDeclareBlock(irBuilder, ToExecute);
             irBuilder.SymbolMarshaller.GoBack();
         }
@@ -329,13 +329,13 @@ namespace NoHoPython.Syntax.Statements
         {
             handlerCodeBlocks = new Dictionary<MatchHandler, CodeBlock>();
             MatchHandlers.ForEach((handler) => {
-                handlerCodeBlocks.Add(handler, irBuilder.SymbolMarshaller.NewCodeBlock(false));
+                handlerCodeBlocks.Add(handler, irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation));
                 IAstStatement.ForwardDeclareBlock(irBuilder, handler.Statements);
                 irBuilder.SymbolMarshaller.GoBack();
             });
             if(DefaultHandler != null)
             {
-                defaultHandlerCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false);
+                defaultHandlerCodeBlock = irBuilder.SymbolMarshaller.NewCodeBlock(false, SourceLocation);
                 IAstStatement.ForwardDeclareBlock(irBuilder, DefaultHandler);
                 irBuilder.SymbolMarshaller.GoBack();
             }

--- a/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
@@ -70,7 +70,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public IType? ReturnType { get; private set; }
 
-        public ProcedureDeclaration(string name, List<Typing.TypeParameter> typeParameters, IType? returnType, SymbolContainer parentContainer, IScopeSymbol? lastMasterScope, IAstElement errorReportedElement) : base(parentContainer, false)
+        public ProcedureDeclaration(string name, List<Typing.TypeParameter> typeParameters, IType? returnType, SymbolContainer parentContainer, IScopeSymbol? lastMasterScope, IAstElement errorReportedElement) : base(parentContainer, false, errorReportedElement.SourceLocation)
         {
             Name = name;
             TypeParameters = typeParameters;

--- a/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
@@ -20,7 +20,7 @@ namespace NoHoPython.Syntax
             foreach (ProcedureDeclaration procedureDeclaration in ProcedureDeclarations)
                 if(procedureDeclaration.CapturedVariables.Count > 0)
                     foreach (ProcedureDeclaration callSite in procedureDeclaration.CallSiteProcedures)
-                        if(procedureDeclaration != callSite)
+                        if(!procedureDeclaration.IsChildProcedure(callSite))
                             dependentProcedures[callSite].Add(procedureDeclaration);
 
             while (unprocessedProcedures.Count > 0)
@@ -83,6 +83,8 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             UsedTypeParameters = new List<Typing.TypeParameter>();
         }
 
+        public override string ToString() => Name;
+
         public bool HasVariable(Variable variable)
         {
             if (variable.ParentProcedure == this)
@@ -99,6 +101,18 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 #pragma warning disable CS8602 // Parameters linked after initialization
                 return !Parameters.Contains(variable);
 #pragma warning restore CS8602
+            return false;
+        }
+
+        public bool IsChildProcedure(ProcedureDeclaration potentialChild)
+        {
+            IScopeSymbol? current = potentialChild;
+            while(current is ProcedureDeclaration procedureDeclaration)
+            {
+                if (procedureDeclaration == this)
+                    return true;
+                current = procedureDeclaration.LastMasterScope;
+            }
             return false;
         }
 

--- a/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
@@ -118,11 +118,19 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public override void DelayedLinkSetStatements(List<IRStatement> statements, AstIRProgramBuilder irBuilder)
         {
-            if (ReturnType == null)
+            if (ReturnType == null || Parameters == null)
                 throw new InvalidOperationException();
             base.DelayedLinkSetStatements(statements, irBuilder);
             if (ReturnType is not NothingType && !CodeBlockAllCodePathsReturn())
                 throw new NotAllCodePathsReturnError(ErrorReportedElement);
+
+            irBuilder.ScopedProcedures.Push(this);
+            foreach (Variable parameter in Parameters)
+                parameter.Type.ScopeForUsedTypeParameters(irBuilder);
+            foreach (Variable capturedVariable in CapturedVariables)
+                capturedVariable.Type.ScopeForUsedTypeParameters(irBuilder);
+            ReturnType.ScopeForUsedTypeParameters(irBuilder);
+            irBuilder.ScopedProcedures.Pop();
         }
 
         public Tuple<Variable, bool> SanitizeVariable(Variable variable, bool willStet, IAstElement errorReportedElement)

--- a/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
@@ -37,7 +37,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public List<Property> GetProperties();
 
-        public void EmitGetProperty(IRProgram irProgram, StringBuilder emitter, string valueCSource, Property property);
+        public void EmitGetProperty(IRProgram irProgram, IEmitter emitter, string valueCSource, Property property);
     }
 
     public abstract class Property

--- a/NoHoPython/IntermediateRepresentation/Values/Literals.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Literals.cs
@@ -176,7 +176,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 else if (interpolatedValues[i] is string str)
                 {
                     if (str != string.Empty)
-                        InterpolatedValues.Add(i);
+                        InterpolatedValues.Add(str);
                 }
                 else
                     throw new InvalidOperationException();

--- a/NoHoPython/IntermediateRepresentation/Values/Literals.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Literals.cs
@@ -157,7 +157,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public InterpolatedString(List<object> interpolatedValues, IAstElement errorReportedElement)
         {
-            InterpolatedValues = interpolatedValues;
+            InterpolatedValues = new(interpolatedValues.Count);
             ErrorReportedElement = errorReportedElement;
 
             for (int i = 0; i < interpolatedValues.Count; i++)
@@ -166,15 +166,18 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 {
                     try
                     {
-                        irValue.Type.GetFormatSpecifier();
+                        InterpolatedValues.Add(ArithmeticCast.CastTo(irValue, new ArrayType(Primitive.Character)));
                     }
-                    catch (NoFormatSpecifierForType) //values without a format specifier are cast to strings
+                    catch //values without a format specifier are cast to strings
                     {
-                        interpolatedValues[i] = ArithmeticCast.CastTo(irValue, new ArrayType(Primitive.Character));
+                        InterpolatedValues.Add(irValue);
                     }
                 }
-                else if (interpolatedValues[i] is string)
-                    continue;
+                else if (interpolatedValues[i] is string str)
+                {
+                    if (str != string.Empty)
+                        InterpolatedValues.Add(i);
+                }
                 else
                     throw new InvalidOperationException();
             }

--- a/NoHoPython/IntermediateRepresentation/Values/Operators.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Operators.cs
@@ -49,7 +49,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         {
             Operation = operation;
 
-            if (left.Type is IPropertyContainer propertyContainer && !propertyContainer.HasProperty("compare"))
+            if (left.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty("compare"))
             {
                 Left = ArithmeticCast.CastTo(new AnonymousProcedureCall(new GetPropertyValue(left, "compare", errorReportedElement), new List<IRValue>()
                 {

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -81,7 +81,7 @@ public static class Program
             Console.WriteLine($"Compilation succesfully finished, taking {DateTime.Now - compileStart}. Output is in {outputFile}.");
             if (program.EmitLineDirectives)
             {
-                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it.");
+                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it. Please not that this feature doesn't work very well at the moment, and is still experimental.");
             }
         }
         catch (SyntaxError syntaxError)
@@ -99,6 +99,11 @@ public static class Program
         catch (FileNotFoundException f)
         {
             Console.WriteLine($"File not found: {f.Message}");
+        }
+        catch(InvalidOperationException e)
+        {
+            Console.WriteLine("An internal compiler error has occured; please report the following stack trace to https://github.com/TheRealMichaelWang/NoHoPython/issues/new.");
+            Console.WriteLine(e.StackTrace);
         }
 
         return 0;

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -56,7 +56,7 @@ public static class Program
             for (int i = 2; i < args.Length; i++)
                 flags.Add(args[i]);
             AstIRProgramBuilder astIRProgramBuilder = new(statements, flags);
-            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), memoryAnalyzer);
+            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), args.Contains("-namert"), memoryAnalyzer);
             parser.IncludeCFiles(program);
 
             string outputFile;

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -47,7 +47,7 @@ public static class Program
                 return MemoryAnalyzer.AnalysisMode.None;
             }
 
-            MemoryAnalyzer memoryAnalyzer = new MemoryAnalyzer(requestedAnalysisMode(), args.Contains("-memfail"));
+            MemoryAnalyzer memoryAnalyzer = new(requestedAnalysisMode(), args.Contains("-memfail"));
             if (OperatingSystem.IsWindows())
                 flags.Add("windows");
             else if (OperatingSystem.IsLinux())

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -65,23 +65,19 @@ public static class Program
             else
                 outputFile = "out.c";
 
-            StringBuilder output = new();
             if (args.Contains("-header"))
             {
                 string headerName = outputFile.EndsWith(".c") ? outputFile.Replace(".c", ".h") : outputFile + ".h";
-                StringBuilder headerBuilder = new();
                 program.IncludeCFile(headerName);
-                program.Emit(output, headerBuilder);
-                File.WriteAllText(headerName, headerBuilder.ToString());
+                program.Emit(outputFile, headerName);
             }
             else
-                program.Emit(output, output);
+                program.Emit(outputFile, null);
 
-            File.WriteAllText(outputFile, output.ToString());
             Console.WriteLine($"Compilation succesfully finished, taking {DateTime.Now - compileStart}. Output is in {outputFile}.");
             if (program.EmitLineDirectives)
             {
-                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it. Please not that this feature doesn't work very well at the moment, and is still experimental.");
+                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it. Please not that this feature doesn't work very well at the moment, and is still experimental. In addition, unless you want to debug internal gdb code, type \"skip file {outputFile}\", then run.");
             }
         }
         catch (SyntaxError syntaxError)

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -56,7 +56,7 @@ public static class Program
             for (int i = 2; i < args.Length; i++)
                 flags.Add(args[i]);
             AstIRProgramBuilder astIRProgramBuilder = new(statements, flags);
-            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), !args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), memoryAnalyzer);
+            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), memoryAnalyzer);
             parser.IncludeCFiles(program);
 
             string outputFile;

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -56,7 +56,7 @@ public static class Program
             for (int i = 2; i < args.Length; i++)
                 flags.Add(args[i]);
             AstIRProgramBuilder astIRProgramBuilder = new(statements, flags);
-            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), args.Contains("-namert"), memoryAnalyzer);
+            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), args.Contains("-namert"), args.Contains("-linedir") || args.Contains("-ggdb"), memoryAnalyzer);
             parser.IncludeCFiles(program);
 
             string outputFile;
@@ -79,6 +79,10 @@ public static class Program
 
             File.WriteAllText(outputFile, output.ToString());
             Console.WriteLine($"Compilation succesfully finished, taking {DateTime.Now - compileStart}. Output is in {outputFile}.");
+            if (program.EmitLineDirectives)
+            {
+                Console.WriteLine($"GCC line directives have been enabled; please use the -ggdb flag while compiling {outputFile}, and gdb to debug it.");
+            }
         }
         catch (SyntaxError syntaxError)
         {

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "\"E:\\calcgod2\\src\\main.nhp\"\r\nout.c"
+      "commandLineArgs": "tests/list-test.nhp\r\nout.c"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/mem-test.nhp\r\nout.c\r\n-leaksan"
+      "commandLineArgs": "\"E:\\calcgod2\\src\\main.nhp\"\r\nout.c"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert"
+      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert\r\n-linedir\r\n-stacktrace"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/list-test.nhp\r\nout.c"
+      "commandLineArgs": "\"E:\\calcgod2\\src\\main.nhp\"\r\nout.c"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "\"E:\\calcgod2\\src\\main.nhp\"\r\nout.c"
+      "commandLineArgs": "tests/enum-test2.nhp\r\nout.c\r\n-namert"
     }
   }
 }

--- a/NoHoPython/Scoping/SymbolMarshaller.cs
+++ b/NoHoPython/Scoping/SymbolMarshaller.cs
@@ -62,7 +62,7 @@ namespace NoHoPython.Scoping
             public void DelayedLinkSetStatements(List<IRStatement> statements) => this.statements.AddRange(statements);
 
             public void ScopeForUsedTypes(Dictionary<Typing.TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => throw new InvalidOperationException();
-            public void Emit(IRProgram irProgram, StringBuilder emitter, Dictionary<Typing.TypeParameter, IType> typeargs, int indent) => throw new InvalidOperationException();
+            public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<Typing.TypeParameter, IType> typeargs, int indent) => throw new InvalidOperationException();
             public bool AllCodePathsReturn() => throw new InvalidOperationException();
 
             public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => throw new InvalidOperationException();
@@ -147,9 +147,9 @@ namespace NoHoPython.Scoping
             scopeStack.Push(symbolContainer);
         }
 
-        public CodeBlock NewCodeBlock(bool isLoop)
+        public CodeBlock NewCodeBlock(bool isLoop, SourceLocation blockBeginLocation)
         {
-            CodeBlock codeBlock = new(scopeStack.Peek(), isLoop);
+            CodeBlock codeBlock = new(scopeStack.Peek(), isLoop, blockBeginLocation);
             NavigateToScope(codeBlock);
             return codeBlock;
         }

--- a/NoHoPython/Syntax/Ast.cs
+++ b/NoHoPython/Syntax/Ast.cs
@@ -1,6 +1,7 @@
 ﻿using NoHoPython.IntermediateRepresentation;
 using NoHoPython.IntermediateRepresentation.Values;
 using NoHoPython.Typing;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace NoHoPython.Syntax
@@ -57,6 +58,22 @@ namespace NoHoPython.Syntax
         }
 
         public override string ToString() => $"File \"{File}\", row {Row}, col {Column}";
+
+        public void EmitLineDirective(StringBuilder emitter)
+        {
+            emitter.Append($"#line {Row} ");
+
+            if (OperatingSystem.IsWindows())
+            {
+                //assumes windows gdb users are using cygwin
+                var pathParts = Path.GetRelativePath(@"C:\", File).Split(Path.DirectorySeparatorChar);
+                CharacterLiteral.EmitCString(emitter, $"/cygdrive/c/{string.Join('/', pathParts)}", false, true);
+            }
+            else
+                CharacterLiteral.EmitCString(emitter, File, false, true);
+
+            emitter.AppendLine();
+        }
     }
 
     public interface ISourceLocatable

--- a/NoHoPython/Syntax/Ast.cs
+++ b/NoHoPython/Syntax/Ast.cs
@@ -8,7 +8,7 @@ namespace NoHoPython.Syntax
 {
     public interface IAstElement : ISourceLocatable
     { 
-        public void EmitSrcAsCString(StringBuilder emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
+        public void EmitSrcAsCString(IEmitter emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
         {
             if (this is IAstValue astValue)
                 CharacterLiteral.EmitCString(emitter, astValue.ToString(), formatStr, encapsulateWithQuotes);
@@ -59,7 +59,7 @@ namespace NoHoPython.Syntax
 
         public override string ToString() => $"File \"{File}\", row {Row}, col {Column}";
 
-        public void EmitLineDirective(StringBuilder emitter)
+        public void EmitLineDirective(IEmitter emitter)
         {
             emitter.Append($"#line {Row} ");
 
@@ -71,8 +71,6 @@ namespace NoHoPython.Syntax
             }
             else
                 CharacterLiteral.EmitCString(emitter, File, false, true);
-
-            emitter.AppendLine();
         }
     }
 

--- a/NoHoPython/Syntax/Ast.cs
+++ b/NoHoPython/Syntax/Ast.cs
@@ -7,12 +7,12 @@ namespace NoHoPython.Syntax
 {
     public interface IAstElement : ISourceLocatable
     { 
-        public void EmitSrcAsCString(StringBuilder emitter, bool encapsulateWithQuotes=true)
+        public void EmitSrcAsCString(StringBuilder emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
         {
             if (this is IAstValue astValue)
-                CharacterLiteral.EmitCString(emitter, astValue.ToString(), false, encapsulateWithQuotes);
+                CharacterLiteral.EmitCString(emitter, astValue.ToString(), formatStr, encapsulateWithQuotes);
             else if (this is IAstStatement astStatement)
-                CharacterLiteral.EmitCString(emitter, astStatement.ToString(0), false, encapsulateWithQuotes);
+                CharacterLiteral.EmitCString(emitter, astStatement.ToString(0), formatStr, encapsulateWithQuotes);
         }
     }
 

--- a/NoHoPython/Syntax/Parsing/InterpolatedString.cs
+++ b/NoHoPython/Syntax/Parsing/InterpolatedString.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace NoHoPython.Syntax.Parsing
 {
@@ -72,7 +68,7 @@ namespace NoHoPython.Syntax.Parsing
                 if (lastChar == '}')
                 {
                     ScanChar();
-                    return new Token(TokenType.OpenBrace, string.Empty);
+                    return new Token(TokenType.CloseBrace, string.Empty);
                 }
 
                 if (depth == 0) //begin interpolation parsing
@@ -98,7 +94,7 @@ namespace NoHoPython.Syntax.Parsing
                             }
                             else //next will be tokens for interpolated values
                             {
-                                interpolationDepths.Push(0);
+                                //interpolationDepths.Push(0);
                                 return LastToken = new Token(TokenType.InterpolatedMiddle, buffer.ToString());
                             }
                         }
@@ -110,7 +106,7 @@ namespace NoHoPython.Syntax.Parsing
                 {
                     interpolationDepths.Pop();
                     interpolationDepths.Push(depth - 1);
-                    return new Token(TokenType.OpenBrace, string.Empty);
+                    return new Token(TokenType.CloseBrace, string.Empty);
                 }
             }
             else

--- a/NoHoPython/Syntax/Parsing/InterpolatedString.cs
+++ b/NoHoPython/Syntax/Parsing/InterpolatedString.cs
@@ -65,12 +65,6 @@ namespace NoHoPython.Syntax.Parsing
             else if (lastChar == '}')
             {
                 ScanChar();
-                if (lastChar == '}')
-                {
-                    ScanChar();
-                    return new Token(TokenType.CloseBrace, string.Empty);
-                }
-
                 if (depth == 0) //begin interpolation parsing
                 {
                     StringBuilder buffer = new();

--- a/NoHoPython/Syntax/Parsing/InterpolatedString.cs
+++ b/NoHoPython/Syntax/Parsing/InterpolatedString.cs
@@ -14,14 +14,14 @@ namespace NoHoPython.Syntax.Parsing
         {
             ScanChar();
             if (lastChar != '\"')
-                throw new UnexpectedCharacterException('\"', lastChar);
+                throw new UnexpectedCharacterException('\"', lastChar, CurrentLocation);
             ScanChar();
 
             StringBuilder buffer = new();
             while (true)
             {
                 if (lastChar == '\0')
-                    throw new UnexpectedCharacterException('\0', lastChar);
+                    throw new UnexpectedCharacterException('\0', lastChar, CurrentLocation);
                 else if (lastChar == '\"') //regular string
                 {
                     ScanChar();
@@ -45,7 +45,7 @@ namespace NoHoPython.Syntax.Parsing
                 {
                     ScanChar();
                     if (lastChar != '}')
-                        throw new UnexpectedCharacterException('}', lastChar);
+                        throw new UnexpectedCharacterException('}', lastChar, CurrentLocation);
                     ScanChar();
                     buffer.Append('}');
                 }
@@ -81,7 +81,7 @@ namespace NoHoPython.Syntax.Parsing
                     while (true)
                     {
                         if (lastChar == '\0')
-                            throw new UnexpectedCharacterException('\0', lastChar);
+                            throw new UnexpectedCharacterException('\0', lastChar, CurrentLocation);
                         else if (lastChar == '\"') //regular string
                         {
                             ScanChar();

--- a/NoHoPython/Syntax/Parsing/Parser.cs
+++ b/NoHoPython/Syntax/Parsing/Parser.cs
@@ -368,6 +368,11 @@ namespace NoHoPython.Syntax.Parsing
                         scanner.ScanToken();
                         value = new ExplicitCast(value, ParseType(), value.SourceLocation);
                     }
+                    else if(scanner.LastToken.Type == TokenType.Is)
+                    {
+                        scanner.ScanToken();
+                        value = new CheckEnumOption(value, ParseType(), value.SourceLocation);
+                    }
                     else
                         break;
                 }

--- a/NoHoPython/Syntax/Parsing/Scanner.cs
+++ b/NoHoPython/Syntax/Parsing/Scanner.cs
@@ -310,7 +310,7 @@ namespace NoHoPython.Syntax.Parsing
                     "assert" => TokenType.Assert,
                     "del" => TokenType.Destroy,
                     "destroy" => TokenType.Destroy,
-                    "in" => TokenType.In,
+                    "is" => TokenType.Is,
                     "from" => TokenType.From,
                     "to" => TokenType.To,
                     "within" => TokenType.Within,

--- a/NoHoPython/Syntax/Parsing/Scanner.cs
+++ b/NoHoPython/Syntax/Parsing/Scanner.cs
@@ -2,28 +2,28 @@
 
 namespace NoHoPython.Syntax.Parsing
 {
-    public sealed class UnrecognizedEscapeCharacterException : Exception
+    public sealed class UnrecognizedEscapeCharacterException : SyntaxError
     {
         public char EscapeCharacter { get; private set; }
 
-        public UnrecognizedEscapeCharacterException(char escapeCharacter) : base($"Unrecognized escape character \"{escapeCharacter}\".")
+        public UnrecognizedEscapeCharacterException(char escapeCharacter, SourceLocation sourceLocation) : base(sourceLocation, $"Unrecognized escape character \"{escapeCharacter}\".")
         {
             EscapeCharacter = escapeCharacter;
         }
     }
 
-    public sealed class UnexpectedCharacterException : Exception
+    public sealed class UnexpectedCharacterException : SyntaxError
     {
         public char? ExpectedCharacter { get; private set; }
         public char RecievedCharacter { get; private set; }
 
-        public UnexpectedCharacterException(char expectedCharacter, char recievedCharacter) : base($"Expected {expectedCharacter} but got {recievedCharacter} instead.")
+        public UnexpectedCharacterException(char expectedCharacter, char recievedCharacter, SourceLocation sourceLocation) : base(sourceLocation, $"Expected {expectedCharacter} but got {recievedCharacter} instead.")
         {
             ExpectedCharacter = expectedCharacter;
             RecievedCharacter = recievedCharacter;
         }
 
-        public UnexpectedCharacterException(char recievedCharacter) : base($"Unexpected character {recievedCharacter}.")
+        public UnexpectedCharacterException(char recievedCharacter, SourceLocation sourceLocation) : base(sourceLocation, $"Unexpected character {recievedCharacter}.")
         {
             RecievedCharacter = recievedCharacter;
             ExpectedCharacter = null;
@@ -136,33 +136,22 @@ namespace NoHoPython.Syntax.Parsing
             char internalScanChar()
             {
                 if (lastChar == '\0')
-                    throw new UnrecognizedEscapeCharacterException('\0');
+                    throw new UnrecognizedEscapeCharacterException('\0', CurrentLocation);
                 else if (lastChar == '\\') //control characters
                 {
-                    char c = ScanChar();
-                    switch (c)
+                    return ScanChar() switch
                     {
-                        case '\"':
-                            return '\"';
-                        case '\'':
-                            return '\'';
-                        case 'a':
-                            return '\a';
-                        case 'b':
-                            return '\b';
-                        case 'f':
-                            return '\f';
-                        case 't':
-                            return '\t';
-                        case 'r':
-                            return '\r';
-                        case 'n':
-                            return '\n';
-                        case '0':
-                            return '\0';
-                        default:
-                            throw new UnrecognizedEscapeCharacterException(c);
-                    }
+                        '\"' => '\"',
+                        '\'' => '\'',
+                        'a' => '\a',
+                        'b' => '\b',
+                        'f' => '\f',
+                        't' => '\t',
+                        'r' => '\r',
+                        'n' => '\n',
+                        '0' => '\0',
+                        _ => throw new UnrecognizedEscapeCharacterException(lastChar, CurrentLocation)
+                    };
                 }
                 else
                     return lastChar;
@@ -267,7 +256,7 @@ namespace NoHoPython.Syntax.Parsing
                         visitorStack.Pop();
                     return TokenType.EndOfFile;
                 default:
-                    throw new UnexpectedCharacterException(symChar);
+                    throw new UnexpectedCharacterException(symChar, CurrentLocation);
             }
         }
 
@@ -359,7 +348,7 @@ namespace NoHoPython.Syntax.Parsing
                 ScanChar();
                 LastToken = new Token(TokenType.CharacterLiteral, ScanCharLiteral().ToString());
                 if (lastChar != '\'')
-                    throw new UnexpectedCharacterException('\'', lastChar);
+                    throw new UnexpectedCharacterException('\'', lastChar, CurrentLocation);
                 ScanChar();
                 return LastToken;
             }
@@ -370,7 +359,7 @@ namespace NoHoPython.Syntax.Parsing
                 while (lastChar != '\"')
                 {
                     if (lastChar == '\0')
-                        throw new UnexpectedCharacterException('\0', lastChar);
+                        throw new UnexpectedCharacterException('\0', lastChar, CurrentLocation);
                     else
                         buffer.Append(ScanCharLiteral());
                 }

--- a/NoHoPython/Syntax/Parsing/Scanner.cs
+++ b/NoHoPython/Syntax/Parsing/Scanner.cs
@@ -50,17 +50,17 @@ namespace NoHoPython.Syntax.Parsing
             {
                 if (!File.Exists(fileName))
                 {
-                    if (File.Exists($"{scanner.standardLibraryDirectory}/{fileName}"))
+                    if (File.Exists(Path.Combine(scanner.standardLibraryDirectory, fileName)))
                     {
-                        fileName = $"{scanner.standardLibraryDirectory}/{fileName}";
+                        fileName = Path.Combine(scanner.standardLibraryDirectory, fileName);
                         goto file_found;
                     }
                     else if (scanner.visitorStack.Count > 0)
                     {
                         FileVisitor parent = scanner.visitorStack.Peek();
-                        if (File.Exists($"{parent.WorkingDirectory}/{fileName}"))
+                        if (File.Exists(Path.Combine(parent.WorkingDirectory, fileName)))
                         {
-                            fileName = $"{parent.WorkingDirectory}/{fileName}";
+                            fileName = Path.Combine(parent.WorkingDirectory, fileName);
                             goto file_found;
                         }
                     }

--- a/NoHoPython/Syntax/Parsing/Tokens.cs
+++ b/NoHoPython/Syntax/Parsing/Tokens.cs
@@ -39,7 +39,7 @@
         CInclude,
         Assert,
         Destroy,
-        In,
+        Is,
         From,
         Within,
         To,

--- a/NoHoPython/Syntax/Statements/Conditional.cs
+++ b/NoHoPython/Syntax/Statements/Conditional.cs
@@ -91,7 +91,9 @@ namespace NoHoPython.Syntax.Statements
         public IAstValue UpperBound { get; private set; }
         public readonly List<IAstStatement> ToExecute;
 
+#pragma warning disable CS8618 //Scoped code block is used only during linking
         public IterationForLoop(string iteratorIdentifier, IAstValue lowerBound, IAstValue upperBound, List<IAstStatement> toExecute, SourceLocation sourceLocation)
+#pragma warning restore CS8618
         {
             IteratorIdentifier = iteratorIdentifier;
             LowerBound = lowerBound;

--- a/NoHoPython/Syntax/Typing.cs
+++ b/NoHoPython/Syntax/Typing.cs
@@ -111,7 +111,7 @@ namespace NoHoPython.Syntax
                             return new EnumType(enumDeclaration, typeArguments, errorReportedElement);
                         else if (typeSymbol is IType symbolType)
                             return symbolType;
-                        throw new NotATypeException(typeSymbol);
+                        throw new NotATypeException(typeSymbol, errorReportedElement);
                     }
             }
         }

--- a/NoHoPython/Syntax/Values/Literals.cs
+++ b/NoHoPython/Syntax/Values/Literals.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using NoHoPython.IntermediateRepresentation;
+using System.Text;
 
 namespace NoHoPython.Syntax.Values
 {
@@ -72,7 +73,7 @@ namespace NoHoPython.Syntax.Values
         {
             if (IsStringLiteral)
             {
-                StringBuilder builder = new();
+                BufferedEmitter builder = new();
                 builder.Append('\"');
                 foreach (IAstValue value in Elements)
                     IntermediateRepresentation.Values.CharacterLiteral.EmitCChar(builder, ((CharacterLiteral)value).Character, false);

--- a/NoHoPython/Syntax/Values/Operators.cs
+++ b/NoHoPython/Syntax/Values/Operators.cs
@@ -180,4 +180,21 @@ namespace NoHoPython.Syntax.Values
         public override string ToString() => $"{Record}.{Property} = {Value}";
         public string ToString(int indent) => $"{IAstStatement.Indent(indent)}{this}";
     }
+
+    public sealed partial class CheckEnumOption : IAstValue
+    {
+        public SourceLocation SourceLocation { get; private set; }
+
+        public IAstValue Enum { get; private set; }
+        public AstType Option { get; private set; }
+
+        public CheckEnumOption(IAstValue @enum, AstType option, SourceLocation sourceLocation)
+        {
+            SourceLocation = sourceLocation;
+            Enum = @enum;
+            Option = option;
+        }
+
+        public override string ToString() => $"{Enum} is {Option}";
+    }
 }

--- a/NoHoPython/Typing/BasicTypes.cs
+++ b/NoHoPython/Typing/BasicTypes.cs
@@ -157,9 +157,9 @@ namespace NoHoPython.Typing
         {
             if (type is ProcedureType procedureType)
             {
-                if (!ReturnType.IsCompatibleWith(procedureType.ReturnType))
-                    return false;
                 if (ParameterTypes.Count != procedureType.ParameterTypes.Count)
+                    return false;
+                if (!ReturnType.IsCompatibleWith(procedureType.ReturnType))
                     return false;
                 for (int i = 0; i < ParameterTypes.Count; i++)
                     if (!procedureType.ParameterTypes[i].IsCompatibleWith(ParameterTypes[i]))

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -105,11 +105,11 @@ namespace NoHoPython.Typing
         }
     }
 
-    public sealed class NotATypeException : Exception
+    public sealed class NotATypeException : IRGenerationError
     {
         public IScopeSymbol ScopeSymbol { get; private set; }
 
-        public NotATypeException(IScopeSymbol scopeSymbol) : base($"{scopeSymbol.Name} is not a type parameter, record, interface, or enum. Rather it is a {scopeSymbol}.")
+        public NotATypeException(IScopeSymbol scopeSymbol, Syntax.IAstElement errorReportedElement) : base(errorReportedElement, $"{scopeSymbol.Name} is not a type parameter, record, interface, or enum. Rather it is a {scopeSymbol}.")
         {
             ScopeSymbol = scopeSymbol;
         }

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -24,7 +24,6 @@ namespace NoHoPython.Typing
         public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer);
         public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource);
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer);
-        //public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource);
 
         public void EmitCStruct(IRProgram irProgram, StringBuilder emitter);
 

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -10,7 +10,6 @@ namespace NoHoPython.Typing
         public bool IsNativeCType { get; }
         public bool RequiresDisposal { get; }
         public bool MustSetResponsibleDestroyer { get; }
-        public bool ContainsRecords { get; }
 
         public string TypeName { get; }
         public string Identifier { get; }
@@ -25,7 +24,7 @@ namespace NoHoPython.Typing
         public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer);
         public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource);
         public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer);
-        public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource);
+        //public void EmitFindChildRecord(IRProgram irProgram, StringBuilder emitter, string valueCSource, string recordCSource);
 
         public void EmitCStruct(IRProgram irProgram, StringBuilder emitter);
 

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -18,14 +18,14 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram);
         public string GetStandardIdentifier(IRProgram irProgram);
 
-        public void EmitFreeValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string childAgent);
-        public void EmitCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitMoveValue(IRProgram irProgram, StringBuilder emitter, string destC, string valueCSource);
-        public void EmitClosureBorrowValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newRecordCSource);
-        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, StringBuilder emitter, string valueCSource, string newResponsibleDestroyer);
+        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent);
+        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
+        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent);
+        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource);
+        public void EmitMutateResponsibleDestroyer(IRProgram irProgram, IEmitter emitter, string valueCSource, string newResponsibleDestroyer);
 
-        public void EmitCStruct(IRProgram irProgram, StringBuilder emitter);
+        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder);
 

--- a/NoHoPython/Typing/TypeParameter.cs
+++ b/NoHoPython/Typing/TypeParameter.cs
@@ -37,6 +37,9 @@ namespace NoHoPython.Typing
             ParentContainer = parentContainer;
         }
 
+        public override int GetHashCode() => IScopeSymbol.GetAbsolouteName(this).GetHashCode();
+        public override bool Equals(object? obj) => obj != null && obj.GetHashCode() == GetHashCode();
+
         public bool SupportsType(IType type)
         {
             return RequiredImplementedInterface == null || RequiredImplementedInterface.IsCompatibleWith(type);

--- a/NoHoPython/Typing/TypeParameter.cs
+++ b/NoHoPython/Typing/TypeParameter.cs
@@ -37,9 +37,6 @@ namespace NoHoPython.Typing
             ParentContainer = parentContainer;
         }
 
-        public override int GetHashCode() => IScopeSymbol.GetAbsolouteName(this).GetHashCode();
-        public override bool Equals(object? obj) => obj != null && obj.GetHashCode() == GetHashCode();
-
         public bool SupportsType(IType type)
         {
             return RequiredImplementedInterface == null || RequiredImplementedInterface.IsCompatibleWith(type);

--- a/NoHoPython/tests/enum-test2.nhp
+++ b/NoHoPython/tests/enum-test2.nhp
@@ -11,7 +11,7 @@ class student:
 		self.name = name
 		self.age = age
 		self.grade = grade
-	def toString() array<char>:
+	def to_array_char() array<char>:
 		return self.name
 
 class faculty:
@@ -23,16 +23,16 @@ class faculty:
 		self.name = name
 		self.age = age
 		self.payment = payment
-	def toString() array<char>:
+	def to_array_char() array<char>:
 		return self.name
 
 interface person:
 	array<char> name
 	int age
 	
-	fn<array<char>> toString
+	fn<array<char>> to_array_char
 
-enum schoolperson: io::stringableObj:
+enum schoolperson: #io::stringableObj:
 	student
 	faculty
 	int
@@ -45,12 +45,12 @@ def writeSchoolPerson(io::writer writer, schoolperson sp):
 		faculty f:
 			writer.write("faculty: ")
 		default:
-			writer.write("int or char")
+			writer.write($"{sp}")
 
 	writer.write(sp)
 
 def main():
 	out = io::output()
-	printSchoolPerson(out, new student("michael", 17, 11))
-	printSchoolPerson(out, new faculty("maine", 40, 140))
-	printSchoolPerson(out, 100)
+	writeSchoolPerson(out, new student("michael", 17, 11))
+	writeSchoolPerson(out, new faculty("maine", 40, 140))
+	writeSchoolPerson(out, 100)

--- a/NoHoPython/tests/interpolation-test.nhp
+++ b/NoHoPython/tests/interpolation-test.nhp
@@ -26,6 +26,7 @@ def interpol_str_test():
 
 	#test two interpolated values
 	output.writeLine($"You're name is {name}, and you're {age} year(s) old!")
+	output.writeLine($"I love {$"nested string interpolation, {name}!"}. You're {age} right?")
 
 	you = new person(name, age)
 	output.writeLine(you)

--- a/NoHoPython/tests/linked-list.nhp
+++ b/NoHoPython/tests/linked-list.nhp
@@ -1,5 +1,7 @@
 ﻿include "mem.nhp"
 
+#linked lists no longer work because of restrictions on match statements; matched variables are copies of the original enum values. See issue #18 for more details
+
 enum nullable<T>:
 	T
 	None


### PR DESCRIPTION
Instead of performing expensive checks (by checking every child, and it's children) to see if a record/object - or child agent - is a child of the current record/object, each record/object can keep track of it's parent record. Then a much faster traversal of the parent records (by examining the parent record, the parent record's parent record, etc...) is all that is needed to perform this check.