### PR TITLE
Message receiver call improvements

### DIFF
--- a/NoHoPython/Compilation/CallStackReporting.cs
+++ b/NoHoPython/Compilation/CallStackReporting.cs
@@ -1,8 +1,6 @@
 ﻿using NoHoPython.IntermediateRepresentation;
-using NoHoPython.IntermediateRepresentation.Statements;
 using NoHoPython.IntermediateRepresentation.Values;
 using NoHoPython.Syntax;
-using System.Text;
 
 namespace NoHoPython.Compilation
 {
@@ -10,7 +8,7 @@ namespace NoHoPython.Compilation
     {
         public static readonly int StackLimit = 1000;
 
-        public static void EmitReporter(StatementEmitter emitter)
+        public static void EmitReporter(Emitter emitter)
         {
             emitter.AppendLine($"static const char* nhp_call_stack_src_locs[{StackLimit}];");
             emitter.AppendLine($"static const char* nhp_call_stack_src[{StackLimit}];");
@@ -43,60 +41,28 @@ namespace NoHoPython.Compilation
             emitter.AppendLine("}");
         }
 
-        public static void EmitReportCall(StatementEmitter emitter, IAstElement errorReportedElement, int indent)
-        {
-            CodeBlock.CIndent(emitter, indent);
-            EmitReportCall(emitter, errorReportedElement);
-            emitter.AppendLine();
-        }
-
-        public static void EmitReportCall(IEmitter emitter, IAstElement errorReportedElement)
+        public static void EmitReportCall(Emitter emitter, IAstElement errorReportedElement)
         {
             emitter.Append("nhp_santize_call(");
             CharacterLiteral.EmitCString(emitter, errorReportedElement.SourceLocation.ToString(), false, true);
             emitter.Append(", ");
             errorReportedElement.EmitSrcAsCString(emitter);
-            emitter.Append(");");
+            emitter.AppendLine(");");
         }
 
-        public static void EmitReportReturn(StatementEmitter emitter, int indent)
-        {
-            CodeBlock.CIndent(emitter, indent);
-            EmitReportReturn(emitter);
-            emitter.AppendLine();
-        }
+        public static void EmitReportReturn(Emitter emitter) => emitter.AppendLine("--nhp_stack_size;");
 
-        public static void EmitReportReturn(IEmitter emitter) => emitter.Append("--nhp_stack_size;");
-
-        public static void EmitErrorLoc(StatementEmitter emitter, IAstElement errorReportedElement, int indent)
-        {
-            CodeBlock.CIndent(emitter, indent);
-            EmitErrorLoc(emitter, errorReportedElement);
-            emitter.AppendLine();
-        }
-
-        public static void EmitErrorLoc(IEmitter emitter, IAstElement errorReportedElement)
+        public static void EmitErrorLoc(Emitter emitter, IAstElement errorReportedElement)
         {
             emitter.Append("nhp_set_errloc(");
             CharacterLiteral.EmitCString(emitter, errorReportedElement.SourceLocation.ToString(), false, true);
             emitter.Append(", ");
             errorReportedElement.EmitSrcAsCString(emitter);
-            emitter.Append(");");
+            emitter.AppendLine(");");
         }
 
-        public static void EmitErrorLoc(StatementEmitter emitter, string locationSrc, string src, int indent)
-        {
-            CodeBlock.CIndent(emitter, indent);
-            emitter.AppendLine($"nhp_set_errloc({locationSrc}, {src});");
-        }
+        public static void EmitErrorLoc(Emitter emitter, string locationSrc, string src) => emitter.AppendLine($"nhp_set_errloc({locationSrc}, {src});");
 
-        public static void EmitPrintStackTrace(StatementEmitter emitter, int indent)
-        {
-            CodeBlock.CIndent(emitter, indent);
-            EmitPrintStackTrace(emitter);
-            emitter.AppendLine();
-        }
-
-        public static void EmitPrintStackTrace(IEmitter emitter) => emitter.Append("nhp_print_stack_trace();");
+        public static void EmitPrintStackTrace(Emitter emitter) => emitter.AppendLine("nhp_print_stack_trace();");
     }
 }

--- a/NoHoPython/Compilation/Errors.cs
+++ b/NoHoPython/Compilation/Errors.cs
@@ -40,26 +40,6 @@ namespace NoHoPython.IntermediateRepresentation
         }
     }
 
-    public sealed class CannotPerformCallStackReporting : CodegenError
-    {
-        public ProcedureCall ProcedureCall { get; private set; }
-
-        public CannotPerformCallStackReporting(ProcedureCall procedureCall) : base(procedureCall, "Cannot perform call stack reporting; please enable expression-statements via ommiting the -nogcc flag.")
-        {
-            ProcedureCall = procedureCall;
-        }
-    }
-
-    public sealed class CannotEmitInterpolatedString : CodegenError
-    {
-        public InterpolatedString InterpolatedString { get; private set; }
-
-        public CannotEmitInterpolatedString(InterpolatedString interpolatedString) : base(interpolatedString, "Cannot emit interpolated string; please emit expression statements via omitting the -nogcc flag.")
-        {
-            InterpolatedString = interpolatedString;
-        }
-    }
-
     public sealed class CannotCompileEmptyTypeError : CodegenError
     {
         public CannotCompileEmptyTypeError(IRElement? errorReportedElement) : base(errorReportedElement, "(Internal Error)Cannot actually compile/emit a nothing literal nor scope a nothing type nor any other type with no associated data.")
@@ -70,7 +50,7 @@ namespace NoHoPython.IntermediateRepresentation
 
     public sealed class CannotConfigureResponsibleDestroyerError : CodegenError
     {
-        public CannotConfigureResponsibleDestroyerError(ProcedureCall procedureCall, IType rawReturnType, string responsibleDestroyer) : base(procedureCall, $"Cannot configure responsible destroyer for call {procedureCall} and raw-return-type {rawReturnType} with {responsibleDestroyer} as the responsible destroyer.")
+        public CannotConfigureResponsibleDestroyerError(ProcedureCall procedureCall, IType rawReturnType) : base(procedureCall, $"Cannot configure responsible destroyer for call {procedureCall} and raw-return-type {rawReturnType}.")
         {
 
         }

--- a/NoHoPython/Compilation/LowLevel.cs
+++ b/NoHoPython/Compilation/LowLevel.cs
@@ -7,23 +7,26 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => TypeToMeasure.SubstituteWithTypearg(typeargs).ScopeForUsedTypes(irBuilder);
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) => emitter.Append($"sizeof({TypeToMeasure.SubstituteWithTypearg(typeargs).GetCName(irProgram)})");
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) => emitter.Append($"sizeof({TypeToMeasure.SubstituteWithTypearg(typeargs).GetCName(irProgram)})"));
     }
 
     partial class MemoryGet
     {
-        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        protected override void EmitExpression(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise left, Emitter.Promise right)
         {
             HandleType handleType = (HandleType)Left.Type;
 
+            primaryEmitter.Append('(');
             if (handleType.ValueType is NothingType)
-                emitter.Append($"(({Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)}*){leftCSource})");
-            else
-                emitter.Append(leftCSource);
-
-            emitter.Append($"[{rightCSource}]");
+                primaryEmitter.Append($"({Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)}*)");
+            left(primaryEmitter);
+            primaryEmitter.Append(")[");
+            right(primaryEmitter);
+            primaryEmitter.Append(']');
         }
     }
 
@@ -37,44 +40,75 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Value.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => !IRValue.EvaluationOrderGuarenteed(Address, Index, Value) || Address.MustUseDestinationPromise(irProgram, typeargs, true) || Index.MustUseDestinationPromise(irProgram, typeargs, true) || Value.MustUseDestinationPromise(irProgram, typeargs, false);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise destinationResponsibleDestroyer, bool isTemporaryEval)
         {
-            if (!IRValue.EvaluationOrderGuarenteed(Address, Index, Value))
-                throw new CannotEnsureOrderOfEvaluation(this);
+            IRValue? responsibleDestroyerVal = Address.GetResponsibleDestroyer();
+            Emitter.Promise responsibleDestroyer = responsibleDestroyerVal != null ? IRValue.EmitDirectPromise(irProgram, responsibleDestroyerVal, typeargs, Emitter.NullPromise, true) : Emitter.NullPromise;
+            HandleType handleType = (HandleType)Address.Type.SubstituteWithTypearg(typeargs);
 
-            HandleType handleType = (HandleType)Address.Type;
-
-            emitter.Append('(');
-            if (handleType.ValueType is NothingType)
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
-                emitter.Append($"(({Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)}*)");
-                IRValue.EmitMemorySafe(Address, irProgram, emitter, typeargs);
-                emitter.Append(')');
+                int indirection = primaryEmitter.AppendStartBlock();
+
+                if (handleType.ValueType is not NothingType)
+                    primaryEmitter.Append($"{handleType.GetCName(irProgram)}");
+                else
+                    primaryEmitter.Append($"{Value.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)}*");
+                primaryEmitter.Append($"address{indirection}; ");
+
+                primaryEmitter.AppendLine($"{Index.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} index{indirection};");
+                Address.Emit(irProgram, primaryEmitter, typeargs, (addressPromise) =>
+                {
+                    primaryEmitter.Append($"address{indirection} = ");
+                    if (handleType.ValueType is NothingType)
+                        primaryEmitter.Append($"({Value.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)}*)");
+                    addressPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                Index.Emit(irProgram, primaryEmitter, typeargs, (indexPromise) =>
+                {
+                    primaryEmitter.Append($"index{indirection} = ");
+                    indexPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                Value.Emit(irProgram, primaryEmitter, typeargs, (valuePromise) =>
+                {
+                    primaryEmitter.Append($"address{indirection}[index{indirection}] = ");
+                    if (Value.RequiresDisposal(irProgram, typeargs, false))
+                        valuePromise(primaryEmitter);
+                    else
+                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, primaryEmitter, valuePromise, responsibleDestroyer);
+                    primaryEmitter.AppendLine(';');
+                }, responsibleDestroyer, false);
+
+                destination((emitter) => primaryEmitter.Append($"address{indirection}[index{indirection}]"));
+                primaryEmitter.AppendEndBlock();
             }
             else
-                IRValue.EmitMemorySafe(Address, irProgram, emitter, typeargs);
-
-            emitter.Append('[');
-            IRValue.EmitMemorySafe(Index, irProgram, emitter, typeargs);
-            emitter.Append("] = ");
-
-            string heapResponsibleDestroyer = ArrayType.GetResponsibleDestroyer(irProgram, typeargs, Address);
-
-            if (Value.RequiresDisposal(typeargs, false))
-                Value.Emit(irProgram, emitter, typeargs, heapResponsibleDestroyer, false);
-            else
-                Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(Value, irProgram, typeargs, "NULL"), heapResponsibleDestroyer);
-            emitter.Append(')');
+                destination((emitter) =>
+                {
+                    emitter.Append("((");
+                    if (handleType.ValueType is NothingType)
+                        emitter.Append($"({Value.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)}*)");
+                    IRValue.EmitDirect(irProgram, emitter, Address, typeargs, Emitter.NullPromise, true);
+                    emitter.Append(")[");
+                    IRValue.EmitDirect(irProgram, emitter, Index, typeargs, Emitter.NullPromise, true);
+                    emitter.Append("] = ");
+                    Value.Emit(irProgram, emitter, typeargs, (valuePromise) =>
+                    {
+                        if (Value.RequiresDisposal(irProgram, typeargs, false))
+                            valuePromise(emitter);
+                        else
+                            Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valuePromise, responsibleDestroyer);
+                    }, responsibleDestroyer, false);
+                });
         }
-        
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
-        {
-            CodeBlock.CIndent(emitter, indent);
-            Emit(irProgram, emitter, typeargs, "NULL", false);
-            emitter.AppendLine(";");
-        }
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs) => IRValue.EmitAsStatement(irProgram, primaryEmitter, this, typeargs);
     }
 
     partial class MarshalHandleIntoArray
@@ -86,27 +120,68 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Address.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Address.MustUseDestinationPromise(irProgram, typeargs, true) || Length.MustUseDestinationPromise(irProgram, typeargs, true) || !Length.IsPure || !IRValue.EvaluationOrderGuarenteed(Address, Length);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            if (!IRValue.EvaluationOrderGuarenteed(Address, Length))
-                throw new CannotEnsureOrderOfEvaluation(this);
-
             ArrayType type = new(ElementType.SubstituteWithTypearg(typeargs));
-            if(ElementType.SubstituteWithTypearg(typeargs).RequiresDisposal)
-                emitter.Append($"marshal_foreign{type.GetStandardIdentifier(irProgram)}(");
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
+            {
+                int indirection = primaryEmitter.AppendStartBlock();
+                primaryEmitter.AppendLine($"{Address.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} addr{indirection}; {Length.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} len{indirection};");
+                Address.Emit(irProgram, primaryEmitter, typeargs, (addrPromise) =>
+                {
+                    primaryEmitter.Append($"addr{indirection} = ");
+                    addrPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                Length.Emit(irProgram, primaryEmitter, typeargs, (lenPromise) =>
+                {
+                    primaryEmitter.Append($"len{indirection} = ");
+                    lenPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                destination((emitter) =>
+                {
+                    if (ElementType.SubstituteWithTypearg(typeargs).RequiresDisposal) 
+                    {
+                        emitter.Append($"marshal_foreign{type.GetStandardIdentifier(irProgram)}(");
+                        emitter.Append($"addr{indirection}, len{indirection}");
+                        if (type.MustSetResponsibleDestroyer)
+                        {
+                            emitter.Append(", ");
+                            responsibleDestroyer(emitter);
+                        }
+                        emitter.Append(')');
+                    }
+                    else
+                    {
+                        emitter.Append($"({type.GetCName(irProgram)}){{.buffer = memcpy({irProgram.MemoryAnalyzer.Allocate($"len{indirection} * sizeof({ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)})")}, addr{indirection}), .length = len{indirection}}}");
+                    }
+                });
+                primaryEmitter.AppendEndBlock();
+            }
             else
-                emitter.Append($"marshal{type.GetStandardIdentifier(irProgram)}(");
-            
-            IRValue.EmitMemorySafe(Address, irProgram, emitter, typeargs);
-            emitter.Append(", ");
-            IRValue.EmitMemorySafe(Length, irProgram, emitter, typeargs);
+                destination((emitter) =>
+                {
+                    emitter.Append($"({type.GetCName(irProgram)}){{.buffer = memcpy(");
+                    irProgram.MemoryAnalyzer.EmitAllocate(emitter, (e) =>
+                    {
+                        IRValue.EmitDirect(irProgram, e, Length, typeargs, Emitter.NullPromise, true);
+                        e.Append($" * sizeof({ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)})");
+                    });
+                    emitter.Append(", ");
+                    IRValue.EmitDirect(irProgram, emitter, Address, typeargs, Emitter.NullPromise, true);
+                    emitter.Append(", ");
+                    IRValue.EmitDirect(irProgram, emitter, Length, typeargs, Emitter.NullPromise, true);
+                    emitter.Append($" * sizeof({ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)}))");
 
-            if (type.MustSetResponsibleDestroyer)
-                emitter.Append($", {responsibleDestroyer})");
-            else
-                emitter.Append(')');
+                    emitter.Append(", .length = ");
+                    IRValue.EmitDirect(irProgram, emitter, Length, typeargs, Emitter.NullPromise, true);
+                    emitter.Append('}');
+                });
         }
     }
 
@@ -118,42 +193,21 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Span.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => !(isTemporaryEval && !Span.RequiresDisposal(typeargs, true));
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Span.RequiresDisposal(irProgram, typeargs, isTemporaryEval);
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Span.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
             ArrayType type = new(ElementType.SubstituteWithTypearg(typeargs));
             MemorySpan memorySpan = (MemorySpan)Span.Type.SubstituteWithTypearg(typeargs);
 
-            if(!RequiresDisposal(typeargs, isTemporaryEval))
+            Span.Emit(irProgram, primaryEmitter, typeargs, (spanPromise) => destination((emitter) =>
             {
                 emitter.Append($"(({type.GetCName(irProgram)}){{ .buffer = ");
-                Span.Emit(irProgram, emitter, typeargs, responsibleDestroyer, true);
+                spanPromise(emitter);
                 emitter.Append($", .length = {memorySpan.Length}}})");
-                return;
-            }
-
-            if (Span.RequiresDisposal(typeargs, false))
-            {
-                emitter.Append($"(({type.GetCName(irProgram)}){{ .buffer = ");
-                Span.Emit(irProgram, emitter, typeargs, responsibleDestroyer, false);
-                emitter.Append($", .length = {memorySpan.Length}}})");
-            }
-            else
-            {
-                if (ElementType.SubstituteWithTypearg(typeargs).RequiresDisposal)
-                    emitter.Append($"marshal_foreign{type.GetStandardIdentifier(irProgram)}(");
-                else
-                    emitter.Append($"marshal{type.GetStandardIdentifier(irProgram)}(");
-
-                Span.Emit(irProgram, emitter, typeargs, "NULL", false);
-                emitter.Append($", {memorySpan.Length}");
-
-                if (type.MustSetResponsibleDestroyer)
-                    emitter.Append($", {responsibleDestroyer})");
-                else
-                    emitter.Append(')');
-            }
+            }), Emitter.NullPromise, isTemporaryEval);
         }
     }
 
@@ -165,85 +219,52 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Value.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => TargetType.SubstituteWithTypearg(typeargs).RequiresDisposal;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => TargetType.SubstituteWithTypearg(typeargs).RequiresDisposal;
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Value.MustUseDestinationPromise(irProgram, typeargs, true) || Value.RequiresDisposal(irProgram, typeargs, true) || !Value.IsPure;
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            List<Property> targetProperties = ((TupleType)TargetType.SubstituteWithTypearg(typeargs)).GetProperties();
+            TupleType targetType = (TupleType)TargetType.SubstituteWithTypearg(typeargs);
+            List<Property> targetProperties = targetType.GetProperties();
 
-            if (Value.IsPure && !Value.RequiresDisposal(typeargs, true))
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
-                emitter.Append($"({TargetType.GetCName(irProgram)}){{");
-                foreach(Property property in targetProperties)
+                int indirection = primaryEmitter.AppendStartBlock();
+                primaryEmitter.AppendLine($"{Value.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} upper{indirection};");
+                Value.Emit(irProgram, primaryEmitter, typeargs, (higherPromise) =>
                 {
-                    if (property != targetProperties.First())
-                        emitter.Append(", ");
-
-                    emitter.Append($".{property.Name} = ");
-
-                    BufferedEmitter higherValueProperty = new();
-                    IRValue.EmitMemorySafe(Value, irProgram, higherValueProperty, typeargs);
-                    higherValueProperty.Append($".{property.Name}");
-                    property.Type.EmitCopyValue(irProgram, emitter, higherValueProperty.ToString(), responsibleDestroyer);
-                }
-                emitter.Append('}');
-            }
-            else
-            {
-                if (!irProgram.EmitExpressionStatements)
-                    throw new CannotEmitDestructorError(Value);
-
-                irProgram.ExpressionDepth++;
-                emitter.Append($"({{{Value.Type.GetCName(irProgram)} higher_tuple{irProgram.ExpressionDepth} = ");
-                Value.Emit(irProgram, emitter, typeargs, "NULL", true);
-                emitter.Append(';');
-
-                if (Value.RequiresDisposal(typeargs, true))
-                    emitter.Append($"{TargetType.GetCName(irProgram)} res{irProgram.ExpressionDepth} = ");
-                
-                emitter.Append($"({TargetType.GetCName(irProgram)}){{");
+                    primaryEmitter.Append($"upper{indirection} = ");
+                    higherPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                primaryEmitter.AppendLine($"{targetType.GetCName(irProgram)} result{indirection};");
                 foreach (Property property in targetProperties)
                 {
-                    if(property != targetProperties.First())
-                        emitter.Append(", ");
-
-                    emitter.Append($".{property.Name} = ");
-                    if (Value.RequiresDisposal(typeargs, true))
-                        emitter.Append($"higher_tuple{irProgram.ExpressionDepth}.{property.Name};");
-                    else
-                    {
-                        property.Type.EmitCopyValue(irProgram, emitter, $"higher_tuple{irProgram.ExpressionDepth}.{property.Name}", responsibleDestroyer);
-                        emitter.Append(';');
-                    }
+                    primaryEmitter.Append($"result{indirection}.{property.Name} = ");
+                    property.Type.EmitCopyValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"upper{indirection}.{property.Name}"), responsibleDestroyer);
+                    primaryEmitter.AppendLine(';');
                 }
-                emitter.Append("};");
-
-                if (Value.RequiresDisposal(typeargs, true))
-                {
-                    TupleType targetTupleType = (TupleType)TargetType.SubstituteWithTypearg(typeargs);
-                    foreach (KeyValuePair<IType, int> valueType in ((TupleType)Value.Type.SubstituteWithTypearg(typeargs)).ValueTypes)
-                    {
-                        if (valueType.Key.RequiresDisposal)
-                        {
-                            if (!targetTupleType.ValueTypes.ContainsKey(valueType.Key))
-                            {
-                                for(int i = 0; i < valueType.Value; i++)
-                                    valueType.Key.EmitFreeValue(irProgram, emitter, $"higher_tuple{irProgram.ExpressionDepth}.{valueType.Key.Identifier}{i}", "NULL");
-                            }
-                            else
-                            {
-                                for (int i = targetTupleType.ValueTypes[valueType.Key]; i < valueType.Value; i++)
-                                    valueType.Key.EmitFreeValue(irProgram, emitter, $"higher_tuple{irProgram.ExpressionDepth}.{valueType.Key.Identifier}{i}", "NULL");
-                            }
-                        }
-                    }
-                    emitter.Append($"res{irProgram.ExpressionDepth};");
-                }
-                else
-                    emitter.Append("})");
-
-                irProgram.ExpressionDepth--;
+                destination((emitter) => emitter.Append($"result{indirection}"));
+                if (Value.RequiresDisposal(irProgram, typeargs, true))
+                    Value.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"upper{indirection}"), Emitter.NullPromise);
+                primaryEmitter.AppendEndBlock();
             }
+            else
+                destination((emitter) =>
+                {
+                    emitter.Append($"({TargetType.GetCName(irProgram)}){{");
+                    foreach (Property property in targetProperties)
+                    {
+                        if (property != targetProperties.First())
+                            emitter.Append(", ");
+
+                        emitter.Append($".{property.Name} = ");
+                        property.Type.EmitCopyValue(irProgram, emitter, IRValue.EmitDirectPromise(irProgram, Value, typeargs, Emitter.NullPromise, true), responsibleDestroyer);
+                        emitter.Append($".{property.Name}");
+                    }
+                    emitter.Append('}');
+                });
         }
     }
 }
@@ -258,23 +279,16 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             Address.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs)
         {
             if (AddressType.ValueType.SubstituteWithTypearg(typeargs).RequiresDisposal)
             {
-                CodeBlock.CIndent(emitter, indent);
-
-                string addressCSrc = BufferedEmitter.EmittedBufferedMemorySafe(Address, irProgram, typeargs);
-                string valueCSrc;
-                if (addressCSrc.StartsWith('&'))
-                    valueCSrc = addressCSrc.Substring(1);
-                else
-                    valueCSrc = $"*{addressCSrc}";
-
-                IRValue? responsibleDestroyer = Address.GetResponsibleDestroyer();
-                AddressType.ValueType.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, valueCSrc, responsibleDestroyer == null ? "NULL" : BufferedEmitter.EmittedBufferedMemorySafe(responsibleDestroyer, irProgram, typeargs));
-
-                emitter.AppendLine();
+                AddressType.ValueType.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => Address.Emit(irProgram, emitter, typeargs, (addressPromise) =>
+                {
+                    emitter.Append("*(");
+                    addressPromise(emitter);
+                    emitter.Append(')');
+                }, Emitter.NullPromise, true), Emitter.NullPromise);
             }
         }
     }

--- a/NoHoPython/Compilation/LowLevel.cs
+++ b/NoHoPython/Compilation/LowLevel.cs
@@ -105,6 +105,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                         else
                             Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, valuePromise, responsibleDestroyer);
                     }, responsibleDestroyer, false);
+                    emitter.Append(')');
                 });
         }
 

--- a/NoHoPython/Compilation/MemoryAnalyzer.cs
+++ b/NoHoPython/Compilation/MemoryAnalyzer.cs
@@ -16,7 +16,15 @@ namespace NoHoPython.Compilation
         public bool ProtectAllocFailure { get; private set; }
 
         public string Allocate(string size) => $"{((Mode == AnalysisMode.None && !ProtectAllocFailure) ? "malloc" : "nhp_malloc")}({size})";
-        public string Dealloc(string ptr, string size) => $"{(Mode == AnalysisMode.None ? "free" : "nhp_free")}({ptr}{(Mode >= AnalysisMode.UsageMagnitudeCheck ? ", " + size : string.Empty)})";
+        public string Dealloc(string ptr, string size) => $"{(Mode == AnalysisMode.None ? "free" : "nhp_free")}({ptr}{(Mode >= AnalysisMode.UsageMagnitudeCheck ? ", " + size : string.Empty)});";
+
+        public void EmitAllocate(Emitter emitter, Emitter.Promise sizePromise)
+        {
+            emitter.Append((Mode == AnalysisMode.None && !ProtectAllocFailure) ? "malloc" : "nhp_malloc");
+            emitter.Append('(');
+            sizePromise(emitter);
+            emitter.Append(')');
+        }
 
         public MemoryAnalyzer(AnalysisMode analysisMode, bool protectAllocFailure)
         {
@@ -24,7 +32,7 @@ namespace NoHoPython.Compilation
             ProtectAllocFailure = protectAllocFailure;
         }
 
-        public void EmitAnalyzers(StatementEmitter emitter)
+        public void EmitAnalyzers(Emitter emitter)
         {
             if (Mode == AnalysisMode.None && !ProtectAllocFailure)
                 return;

--- a/NoHoPython/Compilation/Statements/Conditional.cs
+++ b/NoHoPython/Compilation/Statements/Conditional.cs
@@ -335,7 +335,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             {
                 indirection = primaryEmitter.AppendStartBlock();
                 primaryEmitter.AppendLine($"{enumType.GetCName(irProgram)} matchVal{indirection};");
-                primaryEmitter.SetArgument(MatchValue, $"matchVal{indirection} = ", irProgram, typeargs, true);
+                primaryEmitter.SetArgument(MatchValue, $"matchVal{indirection}", irProgram, typeargs, true);
                 primaryEmitter.AppendLine($"switch(matchVal{indirection}.option) {{");
             }
             else

--- a/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
@@ -208,16 +208,13 @@ namespace NoHoPython.Typing
 
         public void EmitDestructor(IRProgram irProgram, Emitter emitter)
         {
-            emitter.AppendLine($"void free_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} interface, void* child_agent) {{");
+            emitter.AppendStartBlock($"void free_interface{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} interface, void* child_agent)");
 
             foreach (var property in requiredImplementedProperties.Value)
                 if (property.Type.RequiresDisposal)
-                {
-                    emitter.Append('\t');
                     property.Type.EmitFreeValue(irProgram, emitter, (e) => e.Append($"interface.{property.Name}"), (e) => e.Append("child_agent"));
-                    emitter.AppendLine();
-                }
-            emitter.AppendLine("}");
+
+            emitter.AppendEndBlock();
         }
 
         public void EmitCopier(IRProgram irProgram, Emitter emitter)
@@ -282,7 +279,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
                 foreach(Property property in realPrototype.GetProperties())
                 {
-                    primaryEmitter.AppendLine($"result{indirection}.{property.Name} = ");
+                    primaryEmitter.Append($"result{indirection}.{property.Name} = ");
 
 #pragma warning disable CS8602 // property container set in scope for used types
                     Property accessProperty = propertyContainer.FindProperty(property.Name);

--- a/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
@@ -272,7 +272,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
                 int indirection = primaryEmitter.AppendStartBlock();
-                primaryEmitter.AppendLine($"{Value.Type.SubstituteWithTypearg(typeargs)} value{indirection}; {realPrototype.GetCName(irProgram)} result{indirection};");
+                primaryEmitter.AppendLine($"{Value.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} value{indirection}; {realPrototype.GetCName(irProgram)} result{indirection};");
                 Value.Emit(irProgram, primaryEmitter, typeargs, (valuePromise) =>
                 {
                     primaryEmitter.Append($"value{indirection} = ");

--- a/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/InterfaceDeclaration.cs
@@ -270,12 +270,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             {
                 int indirection = primaryEmitter.AppendStartBlock();
                 primaryEmitter.AppendLine($"{Value.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} value{indirection}; {realPrototype.GetCName(irProgram)} result{indirection};");
-                Value.Emit(irProgram, primaryEmitter, typeargs, (valuePromise) =>
-                {
-                    primaryEmitter.Append($"value{indirection} = ");
-                    valuePromise(primaryEmitter);
-                    primaryEmitter.AppendLine(';');
-                }, Emitter.NullPromise, isTemporaryEval);
+                primaryEmitter.SetArgument(Value, $"value{indirection}", irProgram, typeargs, isTemporaryEval);
 
                 foreach(Property property in realPrototype.GetProperties())
                 {
@@ -291,8 +286,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 #pragma warning restore CS8602
                 }
 
-                if (Value.RequiresDisposal(irProgram, typeargs, isTemporaryEval))
-                    Value.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"value{indirection}"), Emitter.NullPromise);
+                primaryEmitter.DestroyBlockResources();
 
                 destination((emitter) => emitter.Append($"result{indirection}"));
 

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -79,11 +79,11 @@ namespace NoHoPython.IntermediateRepresentation
         private List<ProcedureReference> usedProcedureReferences;
         public readonly Dictionary<ProcedureDeclaration, List<ProcedureReference>> ProcedureOverloads;
 
-        public void EmitAnonProcedureTypedefs(StatementEmitter emitter)
+        public void EmitAnonProcedureTypedefs(Emitter emitter)
         {
-            static void EmitProcTypedef(IRProgram irProgram, StatementEmitter emitter, Tuple<ProcedureType, string> procedureInfo)
+            void EmitProcTypedef(Tuple<ProcedureType, string> procedureInfo)
             {
-                static void emitType(IRProgram irProgram, StatementEmitter emitter, IType type)
+                void emitType(IType type)
                 {
                     if (type is RecordType ||
                        type is ProcedureType ||
@@ -92,11 +92,11 @@ namespace NoHoPython.IntermediateRepresentation
                     else if (type is TypeParameterReference typeParameterReference)
                         throw new UnexpectedTypeParameterError(typeParameterReference.TypeParameter, null);
                     else
-                        emitter.Append(type.GetCName(irProgram));
+                        emitter.Append(type.GetCName(this));
                 }
 
                 emitter.Append("typedef ");
-                emitType(irProgram, emitter, procedureInfo.Item1.ReturnType);
+                emitType(procedureInfo.Item1.ReturnType);
                 emitter.Append(" (*");
                 emitter.Append(procedureInfo.Item2);
                 emitter.Append("_t)(void* nhp_capture");
@@ -104,7 +104,7 @@ namespace NoHoPython.IntermediateRepresentation
                 for (int i = 0; i < procedureInfo.Item1.ParameterTypes.Count; i++)
                 {
                     emitter.Append(", ");
-                    emitType(irProgram, emitter, procedureInfo.Item1.ParameterTypes[i]);
+                    emitType(procedureInfo.Item1.ParameterTypes[i]);
                     emitter.Append($" param{i}");
                 }
 
@@ -126,35 +126,7 @@ namespace NoHoPython.IntermediateRepresentation
             emitter.AppendLine("};");
 
             foreach (var uniqueProc in uniqueProcedureTypes)
-                EmitProcTypedef(this, emitter, uniqueProc);
-        }
-
-        public void ForwardDeclareAnonProcedureTypes(IRProgram irProgram, StatementEmitter emitter)
-        {
-            if (irProgram.EmitExpressionStatements)
-                return;
-
-            foreach (var uniqueProcedure in uniqueProcedureTypes)
-            {
-                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src, void* child_agent);");
-            }
-        }
-
-        public void EmitAnonProcedureMovers(IRProgram irProgram, StatementEmitter emitter)
-        {
-            if (irProgram.EmitExpressionStatements)
-                return;
-
-            foreach (var uniqueProcedure in uniqueProcedureTypes)
-            {
-                emitter.AppendLine($"{uniqueProcedure.Item1.GetCName(this)} move{uniqueProcedure.Item2}({uniqueProcedure.Item1.GetCName(this)}* dest, {uniqueProcedure.Item1.GetCName(this)} src, void* child_agent) {{");
-                emitter.Append('\t');
-                uniqueProcedure.Item1.EmitFreeValue(this, emitter, "*dest", "child_agent");
-                emitter.AppendLine();
-                emitter.AppendLine("\t*dest = src;");
-                emitter.AppendLine("\treturn src;");
-                emitter.AppendLine("}");
-            }
+                EmitProcTypedef(uniqueProc);
         }
 
         public string GetAnonProcedureStandardIdentifier(ProcedureType procedureType)
@@ -165,7 +137,7 @@ namespace NoHoPython.IntermediateRepresentation
             throw new InvalidOperationException();
         }
 
-        public void EmitAnonProcedureCapturedContecies(StatementEmitter emitter)
+        public void EmitAnonProcedureCapturedContecies(Emitter emitter)
         {
             foreach (ProcedureReference procedureReference in usedProcedureReferences)
             {
@@ -182,11 +154,32 @@ namespace NoHoPython.IntermediateRepresentation
 {
     partial interface IRValue
     {
-        public static void EmitMemorySafe(IRValue value, IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeArgs)
+        public static void EmitDirect(IRProgram irProgram, Emitter emitter, IRValue value, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) =>
+            value.Emit(irProgram, emitter, typeargs, (setPromise) => setPromise(emitter), responsibleDestroyer, isTemporaryEval);
+
+        public static Emitter.Promise EmitDirectPromise(IRProgram irProgram, IRValue value, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => (emitter) => EmitDirect(irProgram, emitter, value, typeargs, responsibleDestroyer, isTemporaryEval);
+
+        public static void EmitAsStatement(IRProgram irProgram, Emitter emitter, IRValue value, Dictionary<TypeParameter, IType> typeargs)
         {
-            if (value.RequiresDisposal(typeArgs, true))
-                throw new CannotEmitDestructorError(value);
-            value.Emit(irProgram, emitter, typeArgs, "NULL", true);
+            if (value.IsPure)
+                return;
+
+            if (value.RequiresDisposal(irProgram, typeargs, true))
+                value.Emit(irProgram, emitter, typeargs, (valuePromise) => value.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, valuePromise, Emitter.NullPromise), Emitter.NullPromise, true);
+            else
+            {
+                if (value.MustUseDestinationPromise(irProgram, typeargs, true))
+                    value.Emit(irProgram, emitter, typeargs, (valuePromise) =>
+                    {
+                        valuePromise(emitter);
+                        emitter.AppendLine(';');
+                    }, Emitter.NullPromise, true);
+                else
+                {
+                    EmitDirect(irProgram, emitter, value, typeargs, Emitter.NullPromise, true);
+                    emitter.AppendLine(';');
+                }
+            }
         }
     }
 }
@@ -197,15 +190,31 @@ namespace NoHoPython.Typing
     {
         public static string StandardProcedureType => "nhp_anon_proc_info_t*";
 
-        public static void EmitStandardAnonymizer(IRProgram irProgram, StatementEmitter emitter)
+        public static void EmitStandardAnonymizer(IRProgram irProgram, Emitter emitter)
         {
+            emitter.AppendLine("static nhp_anon_proc_info_t* anon_proc_empty_copier(void* to_copy, void* responsible_destroyer);");
             emitter.AppendLine("static nhp_anon_proc_info_t* capture_anon_proc(void* nhp_this_anon) {");
             emitter.AppendLine($"\tnhp_anon_proc_info_t* closure = {irProgram.MemoryAnalyzer.Allocate("sizeof(nhp_anon_proc_info_t)")};");
             emitter.AppendLine("\tclosure->nhp_this_anon = nhp_this_anon;");
             emitter.AppendLine("\tclosure->nhp_destructor = NULL;");
-            emitter.AppendLine("\tclosure->nhp_copier = NULL;");
-            emitter.AppendLine("\tclosure->nhp_record_copier = NULL;");
+            emitter.AppendLine("\tclosure->nhp_copier = anon_proc_empty_copier;");
+            emitter.AppendLine("\tclosure->nhp_record_copier = anon_proc_empty_copier;");
             emitter.AppendLine("\treturn closure;");
+            emitter.AppendLine("}");
+
+            emitter.AppendLine("static nhp_anon_proc_info_t* anon_proc_empty_copier(void* to_copy, void* responsible_destroyer) {");
+            emitter.AppendLine("\treturn capture_anon_proc(((nhp_anon_proc_info_t*)to_copy)->nhp_this_anon);");
+            emitter.AppendLine("}");
+            emitter.AppendLine("static nhp_anon_proc_info_t* anon_proc_copy(nhp_anon_proc_info_t* to_copy, void* responsible_destroyer) {");
+            emitter.AppendLine("\treturn to_copy->nhp_copier(to_copy, responsible_destroyer);");
+            emitter.AppendLine("}");
+            emitter.AppendLine("static nhp_anon_proc_info_t* anon_proc_reccopy(nhp_anon_proc_info_t* to_copy, void* responsible_destroyer) {");
+            emitter.AppendLine("\treturn to_copy->nhp_record_copier(to_copy, responsible_destroyer);");
+            emitter.AppendLine("}");
+
+            emitter.AppendLine("static void anon_proc_destroy(nhp_anon_proc_info_t* to_free, void* child_agent) {");
+            emitter.AppendLine("\tif(to_free->nhp_destructor) { to_free->nhp_destructor(to_free, child_agent); }");
+            emitter.AppendLine($"\telse {{ {irProgram.MemoryAnalyzer.Dealloc($"to_free", "sizeof(nhp_anon_proc_info_t)")} }}");
             emitter.AppendLine("}");
         }
 
@@ -220,21 +229,36 @@ namespace NoHoPython.Typing
 
         public string GetCName(IRProgram irProgram) => StandardProcedureType;
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => emitter.Append($"if(({valueCSource})->nhp_destructor) {{({valueCSource})->nhp_destructor({valueCSource}, {childAgent});}} else {{{irProgram.MemoryAnalyzer.Dealloc(valueCSource, "sizeof(nhp_anon_proc_info_t)")};}}"); 
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"(({valueCSource})->nhp_copier ? ({valueCSource})->nhp_copier({valueCSource}, {responsibleDestroyer}) : (({StandardProcedureType})memcpy({irProgram.MemoryAnalyzer.Allocate($"sizeof(nhp_anon_proc_info_t)")}, {valueCSource}, sizeof(nhp_anon_proc_info_t))))");
-        
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent) 
         {
-            if (irProgram.EmitExpressionStatements)
-                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
-            else
-                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
+            emitter.Append("anon_proc_destroy(");
+            valuePromise(emitter);
+            emitter.Append(", ");
+            childAgent(emitter);
+            emitter.AppendLine(");");
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => emitter.Append($"(({valueCSource})->nhp_record_copier ? ({valueCSource})->nhp_record_copier({valueCSource}, {recordCSource}) : (({StandardProcedureType})memcpy({irProgram.MemoryAnalyzer.Allocate($"sizeof(nhp_anon_proc_info_t)")}, {valueCSource}, sizeof(nhp_anon_proc_info_t))))");
+        public void EmitCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) 
+        {
+            emitter.Append($"({GetCName(irProgram)})anon_proc_copy(");
+            valueCSource(emitter);
+            emitter.Append(", ");
+            responsibleDestroyer(emitter);
+            emitter.Append(')');
+        }
 
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer)
+        {
+            emitter.Append($"({GetCName(irProgram)})anon_proc_reccopy(");
+            valueCSource(emitter);
+            emitter.Append(", ");
+            responsibleDestroyer(emitter);
+            emitter.Append(')');
+        }
+
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter) { }
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -278,7 +302,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             scoping = false; 
         }
 
-        public void ForwardDeclareActual(IRProgram irProgram, StatementEmitter emitter)
+        public void ForwardDeclareActual(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.ProcedureOverloads.ContainsKey(this))
                 return;
@@ -287,9 +311,9 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 procedureReference.ForwardDeclare(irProgram, emitter);
         }
 
-        public override void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
+        public override void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs) { }
 
-        public void EmitActual(IRProgram irProgram, StatementEmitter emitter, int indent)
+        public void EmitActual(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.ProcedureOverloads.ContainsKey(this))
                 return;
@@ -298,8 +322,8 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             {
                 emitter.LastSourceLocation = ErrorReportedElement.SourceLocation;
                 Dictionary<TypeParameter, IType> typeargs = procedureReference.Emit(irProgram, emitter);
-                EmitInitialize(irProgram, emitter, typeargs, indent);
-                EmitNoOpen(irProgram, emitter, typeargs, indent, false);
+                EmitInitialize(irProgram, emitter, typeargs);
+                EmitNoOpen(irProgram, emitter, typeargs, false);
             }
         }
     }
@@ -331,7 +355,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             return procedureReference != null ? procedureReference : this;
         }
 
-        private void EmitCFunctionHeader(IRProgram irProgram, StatementEmitter emitter)
+        private void EmitCFunctionHeader(IRProgram irProgram, Emitter emitter)
         {
 #pragma warning disable CS8604 // Parameters not null when compilation begins
             emitter.Append($"{ReturnType.GetCName(irProgram)} {GetStandardIdentifier(irProgram)}(");
@@ -367,7 +391,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.Append(')');
         }
 
-        public void EmitCaptureCFunctionHeader(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCaptureCFunctionHeader(IRProgram irProgram, Emitter emitter)
         {
             emitter.Append($"{ProcedureType.StandardProcedureType} capture_{GetStandardIdentifier(irProgram)}(");
             foreach (Variable capturedVariable in ProcedureDeclaration.CapturedVariables)
@@ -375,7 +399,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.Append("void* responsible_destroyer, void* fn_ptr)");
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
+        public void ForwardDeclare(IRProgram irProgram, Emitter emitter)
         {
             EmitCFunctionHeader(irProgram, emitter);
             emitter.AppendLine(";");
@@ -387,21 +411,21 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public Dictionary<TypeParameter, IType> Emit(IRProgram irProgram, StatementEmitter emitter)
+        public Dictionary<TypeParameter, IType> Emit(IRProgram irProgram, Emitter emitter)
         {
             EmitCFunctionHeader(irProgram, emitter);
-            emitter.AppendLine(" {");
+            emitter.AppendStartBlock();
             if (IsAnonymous)
             {
                 foreach (Variable variable in ProcedureDeclaration.CapturedVariables)
-                    emitter.AppendLine($"\t{variable.Type.SubstituteWithTypearg(typeArguments).GetCName(irProgram)} {variable.GetStandardIdentifier()} = nhp_captured->{variable.GetStandardIdentifier()};");
+                    emitter.AppendLine($"{variable.Type.SubstituteWithTypearg(typeArguments).GetCName(irProgram)} {variable.GetStandardIdentifier()} = nhp_captured->{variable.GetStandardIdentifier()};");
             }
             if(ReturnType is not NothingType)
-                emitter.AppendLine($"\t{ReturnType.GetCName(irProgram)} nhp_toret;");
+                emitter.AppendLine($"{ReturnType.GetCName(irProgram)} nhp_toret;");
             return typeArguments;
         }
 
-        public void EmitCaptureContextCStruct(IRProgram irProgram, StatementEmitter emitter, List<ProcedureReference> anonProcedureReferences)
+        public void EmitCaptureContextCStruct(IRProgram irProgram, Emitter emitter, List<ProcedureReference> anonProcedureReferences)
         {
             bool HasCompatibleCaptureContextCStruct(ProcedureReference procedureReference)
             {
@@ -432,7 +456,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void EmitAnonymizer(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitAnonymizer(IRProgram irProgram, Emitter emitter)
         {
             if (!IsAnonymous || ProcedureDeclaration.CapturedVariables.Count == 0 || complementaryProcedureReference != null)
                 return;
@@ -463,14 +487,14 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             foreach (Variable capturedVariable in ProcedureDeclaration.CapturedVariables)
             {
                 emitter.Append($"\tclosure->{capturedVariable.GetStandardIdentifier()} = ");
-                capturedVariable.Type.SubstituteWithTypearg(typeArguments).EmitClosureBorrowValue(irProgram, emitter, capturedVariable.GetStandardIdentifier(), "responsible_destroyer");
+                capturedVariable.Type.SubstituteWithTypearg(typeArguments).EmitClosureBorrowValue(irProgram, emitter, (e) => e.Append(capturedVariable.GetStandardIdentifier()), (e) => e.Append("responsible_destroyer"));
                 emitter.AppendLine(";");
             }
             emitter.AppendLine($"\treturn ({ProcedureType.StandardProcedureType})closure;");
             emitter.AppendLine("}");
         }
 
-        public void EmitAnonDestructor(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitAnonDestructor(IRProgram irProgram, Emitter emitter)
         {
             if (!IsAnonymous || !ProcedureDeclaration.CapturedVariables.Any((variable) => variable.Type.RequiresDisposal) || complementaryProcedureReference != null)
                 return;
@@ -486,15 +510,15 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 if (capturedVariable.Type.SubstituteWithTypearg(typeArguments).RequiresDisposal)
                 {
                     emitter.Append('\t');
-                    capturedVariable.Type.SubstituteWithTypearg(typeArguments).EmitFreeValue(irProgram, emitter, $"to_free->{capturedVariable.GetStandardIdentifier()}", "child_agent");
+                    capturedVariable.Type.SubstituteWithTypearg(typeArguments).EmitFreeValue(irProgram, emitter, (e) => e.Append($"to_free->{capturedVariable.GetStandardIdentifier()}"), (e) => e.Append("child_agent"));
                     emitter.AppendLine();
                 }
 
-            emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("to_free", $"sizeof({GetClosureCaptureCType(irProgram)})")};");
+            emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("to_free", $"sizeof({GetClosureCaptureCType(irProgram)})")}");
             emitter.AppendLine("}");
         }
 
-        public void EmitAnonCopier(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitAnonCopier(IRProgram irProgram, Emitter emitter)
         {
             if (!IsAnonymous || ProcedureDeclaration.CapturedVariables.Count == 0 || complementaryProcedureReference != null)
                 return;
@@ -508,7 +532,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.AppendLine("}");
         }
 
-        public void EmitAnonRecordCopier(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitAnonRecordCopier(IRProgram irProgram, Emitter emitter)
         {
             if (!IsAnonymous || !ProcedureDeclaration.CapturedVariables.Any((variable) => variable.IsRecordSelf) || complementaryProcedureReference != null)
                 return;
@@ -534,40 +558,36 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             ToReturn.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs)
         {
             Variable? localToReturn = null;
             if (ToReturn.Type is not NothingType)
             {
-                CodeBlock.CIndent(emitter, indent);
-                emitter.Append("nhp_toret = ");
-
                 if (ToReturn is VariableReference variableReference && parentProcedure.IsLocalVariable(variableReference.Variable))
                 {
                     localToReturn = variableReference.Variable;
-                    emitter.Append(localToReturn.GetStandardIdentifier());
+                    primaryEmitter.AppendLine($"nhp_toret = {localToReturn.GetStandardIdentifier()};");
                 }
-                else if (ToReturn.RequiresDisposal(typeargs, false))
-                    ToReturn.Emit(irProgram, emitter, typeargs, "ret_responsible_dest", false);
                 else
-                    ToReturn.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(ToReturn, irProgram, typeargs, "NULL"), "ret_responsible_dest");
-
-                emitter.AppendLine(";");
+                    ToReturn.Emit(irProgram, primaryEmitter, typeargs, (toReturnPromise) =>
+                    {
+                        primaryEmitter.Append("nhp_toret = ");
+                        if (ToReturn.RequiresDisposal(irProgram, typeargs, false))
+                            toReturnPromise(primaryEmitter);
+                        else
+                            ToReturn.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, primaryEmitter, toReturnPromise, (e) => e.Append("ret_responsible_dest"));
+                        primaryEmitter.AppendLine(';');
+                    }, (e) => e.Append("ret_responsible_dest"), false);
             }
 
             foreach (Variable variable in activeVariables)
                 if (localToReturn != variable && variable.Type.SubstituteWithTypearg(typeargs).RequiresDisposal)
-                {
-                    CodeBlock.CIndent(emitter, indent);
-                    variable.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, variable.GetStandardIdentifier(), "NULL");
-                    emitter.AppendLine();
-                }
+                    variable.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (e) => e.Append(variable.GetStandardIdentifier()), Emitter.NullPromise);
 
-            CodeBlock.CIndent(emitter, indent);
             if (ToReturn.Type is not NothingType)
-                emitter.AppendLine("return nhp_toret;");
+                primaryEmitter.AppendLine("return nhp_toret;");
             else
-                emitter.AppendLine("return;");
+                primaryEmitter.AppendLine("return;");
         }
     }
 
@@ -582,54 +602,53 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs)
         {
-            CodeBlock.CIndent(emitter, indent);
-            emitter.AppendLine("{");
+            primaryEmitter.AppendStartBlock();
 
             if (irProgram.DoCallStack)
             {
-                CallStackReporting.EmitErrorLoc(emitter, ErrorReportedElement, indent + 1);
-                CallStackReporting.EmitPrintStackTrace(emitter, indent + 1);
+                CallStackReporting.EmitErrorLoc(primaryEmitter, ErrorReportedElement);
+                CallStackReporting.EmitPrintStackTrace(primaryEmitter);
             }
 
-            CodeBlock.CIndent(emitter, indent + 1);
             if (AbortMessage != null)
             {
                 if (AbortMessage.Type is HandleType) {
-                    emitter.Append("printf(\"AbortError: %s\\n\", ");
-                    AbortMessage.Emit(irProgram, emitter, typeargs, "NULL", true);
-                    emitter.AppendLine(");");
+                    AbortMessage.Emit(irProgram, primaryEmitter, typeargs, (messagePromise) =>
+                    {
+                        primaryEmitter.Append("printf(\"AbortError: %s\\n\", ");
+                        messagePromise(primaryEmitter);
+                        primaryEmitter.AppendLine(");");
+                    }, Emitter.NullPromise, true);
                 } 
                 else
                 {
-                    emitter.Append($"{AbortMessage.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_abort_msg = ");
-                    AbortMessage.Emit(irProgram, emitter, typeargs, "NULL", true);
-                    emitter.AppendLine(";");
-
-                    CodeBlock.CIndent(emitter, indent + 1);
-                    emitter.Append("printf(\"AbortError: ");
-                    if (AbortMessage.Type is ArrayType)
-                        emitter.AppendLine("%.*s\\n\", nhp_abort_msg.length, nhp_abort_msg.buffer);");
-                    else
-                        emitter.AppendLine("%s\\n\", nhp_abort_msg->cstr);");
-
-                    if (AbortMessage.RequiresDisposal(typeargs, true))
+                    primaryEmitter.AppendLine($"{AbortMessage.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_abort_msg;");
+                    AbortMessage.Emit(irProgram, primaryEmitter, typeargs, (messagePromise) =>
                     {
-                        CodeBlock.CIndent(emitter, indent + 1);
-                        AbortMessage.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, "nhp_abort_msg", "NULL");
-                        emitter.AppendLine();
-                    }
+                        primaryEmitter.Append("nhp_abort_msg = ");
+                        messagePromise(primaryEmitter);
+                        primaryEmitter.AppendLine(';');
+                    }, Emitter.NullPromise, true);
+
+                    primaryEmitter.Append("printf(\"AbortError: ");
+                    if (AbortMessage.Type is ArrayType)
+                        primaryEmitter.AppendLine("%.*s\\n\", nhp_abort_msg.length, nhp_abort_msg.buffer);");
+                    else if (AbortMessage.Type is RecordType)
+                        primaryEmitter.AppendLine("%s\\n\", nhp_abort_msg->cstr);");
+                    else
+                        throw new UnexpectedTypeException(AbortMessage.Type, ErrorReportedElement);
+
+                    if (AbortMessage.RequiresDisposal(irProgram, typeargs, true))
+                        AbortMessage.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (e) => e.Append("nhp_abort_msg"), Emitter.NullPromise);
                 }
             }
             else
-                emitter.Append("puts(\"AbortError: No message given.\");");
+                primaryEmitter.Append("puts(\"AbortError: No message given.\");");
 
-            CodeBlock.CIndent(emitter, indent + 1);
-            emitter.AppendLine("abort();");
-
-            CodeBlock.CIndent(emitter, indent);
-            emitter.AppendLine("}");
+            primaryEmitter.AppendLine("abort();");
+            primaryEmitter.AppendEndBlock();
         }
     }
 
@@ -637,7 +656,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
     {
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent) { }
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs) { }
     }
 }
 
@@ -645,7 +664,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
 {
     partial class ProcedureCall
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Type.SubstituteWithTypearg(typeargs).RequiresDisposal;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Type.SubstituteWithTypearg(typeargs).RequiresDisposal;
+
+        protected virtual bool ArgumentEvalautionOrderGuarenteed() => IRValue.EvaluationOrderGuarenteed(Arguments);
+
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Arguments.Any((arg) => arg.RequiresDisposal(irProgram, typeargs, true) || arg.MustUseDestinationPromise(irProgram, typeargs, true)) || !ArgumentEvalautionOrderGuarenteed() || irProgram.DoCallStack;
 
         public virtual void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -653,146 +676,77 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Arguments.ForEach((arg) => arg.ScopeForUsedTypes(typeargs, irBuilder));
         }
 
-        public abstract void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer);
+        public abstract void EmitCall(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, List<Emitter.Promise> argPromises, Emitter.Promise responsibleDestroyer);
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            irProgram.ExpressionDepth++;
-            if (irProgram.DoCallStack)
-            {
-                if (!irProgram.EmitExpressionStatements)
-                    throw new CannotPerformCallStackReporting(this);
-                emitter.Append("({");
-                CallStackReporting.EmitReportCall(emitter, ErrorReportedElement);
-                emitter.Append($"{Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_callrep_res{irProgram.ExpressionDepth} = ");
-            }
+            bool shouldBufferArg(int i) => !Arguments[i].IsConstant || Arguments[i].MustUseDestinationPromise(irProgram, typeargs, true) || Arguments[i].RequiresDisposal(irProgram, typeargs, true);
 
-            if ((irProgram.EmitExpressionStatements && Arguments.Any((arg) => arg.RequiresDisposal(typeargs, true))) 
-                || !IRValue.EvaluationOrderGuarenteed(Arguments))
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
-                if (!irProgram.EmitExpressionStatements)
-                    throw new CannotEnsureOrderOfEvaluation(this);
+                int indirection = primaryEmitter.AppendStartBlock();
 
-                emitter.Append("({");
-                SortedSet<int> bufferedArguments = new();
+                if(irProgram.DoCallStack)
+                    CallStackReporting.EmitReportCall(primaryEmitter, ErrorReportedElement);
+
                 for (int i = 0; i < Arguments.Count; i++)
-                    if (Arguments[i].RequiresDisposal(typeargs, true) || !Arguments[i].IsConstant || !Arguments[i].IsPure)
+                    if (shouldBufferArg(i))
+                        primaryEmitter.Append($"{Arguments[i].Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} arg{i}{indirection}; ");
+                primaryEmitter.AppendLine();
+
+                List<Emitter.Promise> argPromises = new(Arguments.Count);
+                for (int i = 0; i < Arguments.Count; i++)
+                {
+                    int j = i;
+                    if (shouldBufferArg(i))
                     {
-                        emitter.Append($"{Arguments[i].Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_argbuf_{i}{irProgram.ExpressionDepth} = ");
-                        Arguments[i].Emit(irProgram, emitter, typeargs, "NULL", true);
-                        emitter.Append(";");
-                        bufferedArguments.Add(i);
+                        Arguments[i].Emit(irProgram, primaryEmitter, typeargs, (argPromise) =>
+                        {
+                            primaryEmitter.Append($"arg{i}{indirection} = ");
+                            argPromise(primaryEmitter);
+                            primaryEmitter.AppendLine(';');
+                        }, Emitter.NullPromise, true);
+                        argPromises.Add((emitter) => emitter.Append($"arg{j}{indirection}"));
                     }
-                emitter.Append($"{Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_res{irProgram.ExpressionDepth} = ");
-                EmitCall(irProgram, emitter, typeargs, bufferedArguments, irProgram.ExpressionDepth, responsibleDestroyer);
-                emitter.Append(';');
+                    else
+                    {
+                        Debug.Assert(!Arguments[i].MustUseDestinationPromise(irProgram, typeargs, true));
+                        argPromises.Add((emitter) => Arguments[j].Emit(irProgram, emitter, typeargs, (argPromise) => argPromise(emitter), Emitter.NullPromise, true));
+                    }
+                }
 
-                foreach (int i in bufferedArguments)
-                    if (Arguments[i].RequiresDisposal(typeargs, true))
-                        Arguments[i].Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, $"nhp_argbuf_{i}{irProgram.ExpressionDepth}", "NULL");
-                emitter.Append($"nhp_res{irProgram.ExpressionDepth};}})");
+                destination((emitter) => EmitCall(irProgram, emitter, typeargs, argPromises, responsibleDestroyer));
+
+                for (int i = 0; i < Arguments.Count; i++)
+                {
+                    if (Arguments[i].RequiresDisposal(irProgram, typeargs, true))
+                        Arguments[i].Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"arg{i}{indirection}"), Emitter.NullPromise);
+                }
+
+                if (irProgram.DoCallStack)
+                    CallStackReporting.EmitReportReturn(primaryEmitter);
+
+                primaryEmitter.AppendEndBlock();
             }
             else
-                EmitCall(irProgram, emitter, typeargs, new(), irProgram.ExpressionDepth, responsibleDestroyer);
-
-            if (irProgram.DoCallStack)
-            {
-                emitter.Append(';');
-                CallStackReporting.EmitReportReturn(emitter);
-                emitter.Append($"nhp_callrep_res{irProgram.ExpressionDepth};}})");
-            }
-
-            irProgram.ExpressionDepth--;
+                destination((emitter) =>
+                {
+                    EmitCall(irProgram, emitter, typeargs, Arguments.ConvertAll<Emitter.Promise>((arg) => (argEmitter) => arg.Emit(irProgram, argEmitter, typeargs, (argPromise) => argPromise(argEmitter), Emitter.NullPromise, true)), responsibleDestroyer);
+                });
         }
 
-        protected void EmitArgument(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int i, int currentNestedCall)
+        protected static void EmitArguments(Emitter emitter, List<Emitter.Promise> argPromises)
         {
-            if (bufferedArguments.Contains(i))
-                emitter.Append($"nhp_argbuf_{i}{currentNestedCall}");
-            else
+            for (int i = 0; i < argPromises.Count; i++)
             {
-                if (Arguments[i].RequiresDisposal(typeargs, true))
-                    throw new CannotEmitDestructorError(Arguments[i]);
-                else if (!IRValue.EvaluationOrderGuarenteed(Arguments) && (!Arguments[i].IsPure || !Arguments[i].IsConstant))
-                    throw new CannotEnsureOrderOfEvaluation(this);
-                else
-                    Arguments[i].Emit(irProgram, emitter, typeargs, "NULL", true);
-            }
-        }
-
-        protected void EmitArguments(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, int startArg = 0)
-        {
-            for (int i = startArg; i < Arguments.Count; i++)
-            {
-                if (i > startArg)
+                if (i > 0)
                     emitter.Append(", ");
 
-                EmitArgument(irProgram, emitter, typeargs, bufferedArguments, i, currentNestedCall);
+                argPromises[i](emitter);
             }
         }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
-        {
-            void emitAndDestroyCall(SortedSet<int> bufferedArguments, int indent)
-            {
-                if (RequiresDisposal(typeargs, true))
-                {
-                    emitter.AppendLine("{");
-                    CodeBlock.CIndent(emitter, indent + 1);
-                    emitter.Append($"{Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_callrep_res0 = ");
-                    EmitCall(irProgram, emitter, typeargs, bufferedArguments, 0, "NULL");
-                    emitter.AppendLine(";");
-                    CodeBlock.CIndent(emitter, indent + 1);
-                    Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, "nhp_callrep_res0", "NULL");
-                    emitter.AppendLine();
-                    CodeBlock.CIndent(emitter, indent);
-                    emitter.AppendLine("}");
-                }
-                else
-                {
-                    EmitCall(irProgram, emitter, typeargs, bufferedArguments, 0, "NULL");
-                    emitter.AppendLine(";");
-                }
-            }
-
-            if(irProgram.DoCallStack)
-                CallStackReporting.EmitReportCall(emitter, ErrorReportedElement, indent);
-
-            CodeBlock.CIndent(emitter, indent);
-
-            if (!Arguments.TrueForAll((arg) => !arg.RequiresDisposal(typeargs, true)) || !IRValue.EvaluationOrderGuarenteed(Arguments))
-            {
-                SortedSet<int> bufferedArguments = new();
-                emitter.AppendLine("{");
-                for (int i = 0; i < Arguments.Count; i++)
-                    if (Arguments[i].RequiresDisposal(typeargs, true) || !Arguments[i].IsConstant || !Arguments[i].IsPure)
-                    {
-                        CodeBlock.CIndent(emitter, indent + 1);
-                        emitter.Append($"{Arguments[i].Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_argbuf_{i}0 = ");
-                        Arguments[i].Emit(irProgram, emitter, typeargs, "NULL", true);
-                        emitter.AppendLine(";");
-                        bufferedArguments.Add(i);
-                    }
-
-                CodeBlock.CIndent(emitter, indent + 1);
-                emitAndDestroyCall(bufferedArguments, indent + 1);
-
-                foreach (int i in bufferedArguments)
-                    if (Arguments[i].RequiresDisposal(typeargs, true))
-                    {
-                        CodeBlock.CIndent(emitter, indent + 1);
-                        Arguments[i].Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, $"nhp_argbuf_{i}0", "NULL");
-                        emitter.AppendLine();
-                    }
-                CodeBlock.CIndent(emitter, indent);
-                emitter.AppendLine("}");
-            }
-            else
-                emitAndDestroyCall(new(), indent);
-
-            if(irProgram.DoCallStack)
-                CallStackReporting.EmitReportReturn(emitter, indent);
-        }
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs) => IRValue.EmitAsStatement(irProgram, primaryEmitter, this, typeargs);
     }
 
     partial class LinkedProcedureCall
@@ -803,44 +757,48 @@ namespace NoHoPython.IntermediateRepresentation.Values
             base.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, List<Emitter.Promise> argPromises, Emitter.Promise responsibleDestroyer)
         {
-            emitter.Append($"{Procedure.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(");
-            EmitArguments(irProgram, emitter, typeargs, bufferedArguments, currentNestedCall);
-            for(int i = 0; i < Procedure.ProcedureDeclaration.CapturedVariables.Count; i++)
+            primaryEmitter.Append($"{Procedure.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(");
+            EmitArguments(primaryEmitter, argPromises);
+            for (int i = 0; i < Procedure.ProcedureDeclaration.CapturedVariables.Count; i++)
             {
                 if (i > 0 || Arguments.Count > 0)
-                    emitter.Append(", ");
-                VariableReference variableReference = new(Procedure.ProcedureDeclaration.CapturedVariables[i], true, null, ErrorReportedElement);
-                variableReference.Emit(irProgram, emitter, typeargs, "NULL", true);
+                    primaryEmitter.Append(", ");
+                IRValue.EmitDirect(irProgram, primaryEmitter, new VariableReference(Procedure.ProcedureDeclaration.CapturedVariables[i], true, null, ErrorReportedElement), typeargs, Emitter.NullPromise, true);
             }
             if (Type.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
             {
                 if (Arguments.Count + Procedure.ProcedureDeclaration.CapturedVariables.Count > 0)
-                    emitter.Append(", ");
-                emitter.Append(responsibleDestroyer);
+                    primaryEmitter.Append(", ");
+                responsibleDestroyer(primaryEmitter);
             }
-            emitter.Append(')');
+            primaryEmitter.Append(')');
         }
     }
 
     partial class AnonymousProcedureCall
     {
-        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        protected override bool ArgumentEvalautionOrderGuarenteed()
         {
-            if (!ProcedureValue.IsPure)
-                throw new CannotEnsureOrderOfEvaluation(this);
+            List<IRValue> arguments = new List<IRValue>(Arguments);
+            arguments.Insert(0, Arguments[0]);
+            return IRValue.EvaluationOrderGuarenteed(arguments);
+        }
 
-            emitter.Append($"(({ProcedureType.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}_t)");
-            EmitArgument(irProgram, emitter, typeargs, bufferedArguments, 0, currentNestedCall);
-            emitter.Append("->nhp_this_anon)(");
-
-            EmitArguments(irProgram, emitter, typeargs, bufferedArguments, currentNestedCall);
+        public override void EmitCall(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, List<Emitter.Promise> argPromises, Emitter.Promise responsibleDestroyer)
+        {
+            primaryEmitter.Append($"(({ProcedureType.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}_t)");
+            argPromises[0](primaryEmitter);
+            primaryEmitter.Append("->nhp_this_anon)(");
+            EmitArguments(primaryEmitter, argPromises);
 
             if (Type.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
-                emitter.Append($", {responsibleDestroyer}");
-
-            emitter.Append(')');
+            {
+                primaryEmitter.Append(", ");
+                responsibleDestroyer(primaryEmitter);
+            }
+            primaryEmitter.Append(')');
         }
     }
 
@@ -871,11 +829,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
             base.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, List<Emitter.Promise> argPromises, Emitter.Promise responsibleDestroyer)
         {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-            emitter.Append($"{toCall.GetStandardIdentifier(irProgram)}(");
-            EmitArguments(irProgram, emitter, typeargs, bufferedArguments, currentNestedCall);
+            primaryEmitter.Append($"{toCall.GetStandardIdentifier(irProgram)}(");
+            EmitArguments(primaryEmitter, argPromises);
 
             if (toCall.ProcedureDeclaration.CapturedVariables.Count > 0)
                 Debug.Assert(Arguments.Last() == Record);
@@ -883,23 +841,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if (toCall.ReturnType.MustSetResponsibleDestroyer)
             {
                 if (Arguments.Count > 0)
-                    emitter.Append(", ");
-                emitter.Append(responsibleDestroyer);
+                    primaryEmitter.Append(", ");
+                responsibleDestroyer(primaryEmitter);
             }
 
-            //if(Arguments.Count > 0 && (toCall.ReturnType.MustSetResponsibleDestroyer || toCall.ProcedureDeclaration.CapturedVariables.Count > 0))
-            //    emitter.Append(", ");
-
-            //if (toCall.ProcedureDeclaration.CapturedVariables.Count > 0)
-            //{
-            //    IRValue.EmitMemorySafe(Record, irProgram, emitter, typeargs);
-            //    if(toCall.ReturnType.MustSetResponsibleDestroyer)
-            //        emitter.Append($", {responsibleDestroyer}");
-            //}
-            //else
-            //    emitter.Append(responsibleDestroyer);
-
-            emitter.Append(')');
+            primaryEmitter.Append(')');
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
         }
     }
@@ -908,7 +854,9 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         ProcedureReference? toAnonymize = null;
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
+
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -916,7 +864,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             toAnonymize = toAnonymize.ScopeForUsedTypes(irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) =>
         {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
             if (GetFunctionHandle)
@@ -924,7 +872,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             else if (Procedure.ProcedureDeclaration.CapturedVariables.Count > 0)
             {
                 emitter.Append($"capture_{toAnonymize.GetComplementaryIdentifier(irProgram)}(");
-                foreach (Variable capturedVar in toAnonymize.ProcedureDeclaration.CapturedVariables) 
+                foreach (Variable capturedVar in toAnonymize.ProcedureDeclaration.CapturedVariables)
                 {
                     if (capturedVar.IsRecordSelf && parentProcedure == null)
                         emitter.Append("nhp_self");
@@ -937,9 +885,9 @@ namespace NoHoPython.IntermediateRepresentation.Values
             else
                 emitter.Append($"capture_anon_proc(&{Procedure.GetStandardIdentifier(irProgram)})");
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
-        }
+        });
 
-        public void EmitForPropertyGet(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string recordCSource, string responsibleDestroyer)
+        public void EmitForPropertyGet(IRProgram irProgram, Emitter emitter, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise recordPromise, Emitter.Promise responsibleDestroyer)
         {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
             Debug.Assert(!GetFunctionHandle);
@@ -948,7 +896,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if(toAnonymize.ProcedureDeclaration.CapturedVariables.Count == 1)
             {
                 Debug.Assert(toAnonymize.ProcedureDeclaration.CapturedVariables[0].IsRecordSelf);
-                emitter.Append($"capture_{toAnonymize.GetComplementaryIdentifier(irProgram)}({recordCSource}, {responsibleDestroyer}, &{Procedure.GetStandardIdentifier(irProgram)})");
+                emitter.Append($"capture_{toAnonymize.GetComplementaryIdentifier(irProgram)}(");
+                recordPromise(emitter);
+                emitter.Append(", ");
+                responsibleDestroyer(emitter);
+                emitter.Append($", &{Procedure.GetStandardIdentifier(irProgram)})");
             }
             else
                 emitter.Append($"capture_anon_proc(&{Procedure.GetStandardIdentifier(irProgram)})");
@@ -960,18 +912,15 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public override void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => base.ScopeForUsedTypes(ProcedureReference.SubstituteTypeargsWithTypeargs(typeArguments, typeargs), irBuilder);
 
-        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> bufferedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, List<Emitter.Promise> argPromises, Emitter.Promise responsibleDestroyer)
         {
-            if (ForeignCProcedure.CFunctionName == null)
-                emitter.Append($"{ForeignCProcedure.Name}(");
-            else
-                emitter.Append($"{ForeignCProcedure.CFunctionName}(");
-            
-            EmitArguments(irProgram, emitter, ProcedureReference.SubstituteTypeargsWithTypeargs(typeArguments, typeargs), bufferedArguments, currentNestedCall);
-            emitter.Append(')');
+            primaryEmitter.Append(ForeignCProcedure.CFunctionName ?? ForeignCProcedure.Name);
+            primaryEmitter.Append('(');
+            EmitArguments(primaryEmitter, argPromises);
+            primaryEmitter.Append(')');
 
-            if (Type.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer && responsibleDestroyer != "NULL")
-                throw new CannotConfigureResponsibleDestroyerError(this, Type.SubstituteWithTypearg(typeargs), responsibleDestroyer);
+            if (Type.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer && responsibleDestroyer != Emitter.NullPromise)
+                throw new CannotConfigureResponsibleDestroyerError(this, Type.SubstituteWithTypearg(typeargs));
         }
     }
 }

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -168,17 +168,11 @@ namespace NoHoPython.IntermediateRepresentation
                 value.Emit(irProgram, emitter, typeargs, (valuePromise) => value.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, valuePromise, Emitter.NullPromise), Emitter.NullPromise, true);
             else
             {
-                if (value.MustUseDestinationPromise(irProgram, typeargs, true))
-                    value.Emit(irProgram, emitter, typeargs, (valuePromise) =>
-                    {
-                        valuePromise(emitter);
-                        emitter.AppendLine(';');
-                    }, Emitter.NullPromise, true);
-                else
+                value.Emit(irProgram, emitter, typeargs, (valuePromise) =>
                 {
-                    EmitDirect(irProgram, emitter, value, typeargs, Emitter.NullPromise, true);
+                    valuePromise(emitter);
                     emitter.AppendLine(';');
-                }
+                }, Emitter.NullPromise, true);
             }
         }
     }

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -604,8 +604,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs)
         {
-            primaryEmitter.AppendStartBlock();
-
             if (irProgram.DoCallStack)
             {
                 CallStackReporting.EmitErrorLoc(primaryEmitter, ErrorReportedElement);
@@ -648,7 +646,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 primaryEmitter.Append("puts(\"AbortError: No message given.\");");
 
             primaryEmitter.AppendLine("abort();");
-            primaryEmitter.AppendEndBlock();
         }
     }
 

--- a/NoHoPython/Compilation/Statements/Procedure.cs
+++ b/NoHoPython/Compilation/Statements/Procedure.cs
@@ -154,8 +154,11 @@ namespace NoHoPython.IntermediateRepresentation
 {
     partial interface IRValue
     {
-        public static void EmitDirect(IRProgram irProgram, Emitter emitter, IRValue value, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) =>
+        public static void EmitDirect(IRProgram irProgram, Emitter emitter, IRValue value, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
+        {
+            Debug.Assert(!value.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval));
             value.Emit(irProgram, emitter, typeargs, (setPromise) => setPromise(emitter), responsibleDestroyer, isTemporaryEval);
+        }
 
         public static Emitter.Promise EmitDirectPromise(IRProgram irProgram, IRValue value, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => (emitter) => EmitDirect(irProgram, emitter, value, typeargs, responsibleDestroyer, isTemporaryEval);
 

--- a/NoHoPython/Compilation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/RecordDeclaration.cs
@@ -44,7 +44,7 @@ namespace NoHoPython.IntermediateRepresentation
     {
         public readonly Dictionary<RecordDeclaration, List<RecordType>> RecordTypeOverloads;
 
-        public void ForwardDeclareRecordTypes(StatementEmitter emitter)
+        public void ForwardDeclareRecordTypes(Emitter emitter)
         {
             foreach(RecordDeclaration recordDeclaration in RecordTypeOverloads.Keys)
             {
@@ -97,27 +97,28 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                     DefaultValue.ScopeForUsedTypes(typeargs, irBuilder);
             }
 
-            public override bool EmitGet(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, IPropertyContainer propertyContainer, string valueCSource, string responsibleDestroyer)
+            public override bool EmitGet(IRProgram irProgram, Emitter emitter, Dictionary<TypeParameter, IType> typeargs, IPropertyContainer propertyContainer, Emitter.Promise value, Emitter.Promise responsibleDestroyer)
             {
                 if (OptimizeMessageReciever)
                 {
 #pragma warning disable CS8600 //DefaultValue != null is a precondition for OptimizeMessageReciever
 #pragma warning disable CS8602
                     AnonymizeProcedure anonymizeProcedure = (AnonymizeProcedure)DefaultValue;
-                    anonymizeProcedure.EmitForPropertyGet(irProgram, emitter, typeargs, valueCSource, responsibleDestroyer);
+                    anonymizeProcedure.EmitForPropertyGet(irProgram, emitter, typeargs, value, responsibleDestroyer);
 #pragma warning restore CS8602
 #pragma warning restore CS8600
                     return true;
                 }
                 else
                 {
-                    emitter.Append($"{valueCSource}->{Name}");
+                    value(emitter);
+                    emitter.Append($"->{Name}");
                     return false;
                 }
             }
         }
 
-        public static void EmitRecordMaskProto(StatementEmitter emitter)
+        public static void EmitRecordMaskProto(Emitter emitter)
         {
             emitter.AppendLine("typedef struct nhp_std_record_mask nhp_std_record_mask_t;");
             emitter.AppendLine("struct nhp_std_record_mask {");
@@ -129,7 +130,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             emitter.AppendLine("typedef void (*nhp_custom_destructor)(void* to_destroy);");
         }
 
-        public static void EmitRecordChildFinder(StatementEmitter emitter)
+        public static void EmitRecordChildFinder(Emitter emitter)
         {
             emitter.AppendLine("static int nhp_record_has_child(nhp_std_record_mask_t* parent, nhp_std_record_mask_t* child) {");
             emitter.AppendLine("\twhile(child != NULL) {");
@@ -143,7 +144,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void ForwardDeclareType(IRProgram irProgram, StatementEmitter emitter)
+        public void ForwardDeclareType(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.RecordTypeOverloads.ContainsKey(this))
                 return;
@@ -170,7 +171,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void ForwardDeclare(IRProgram irProgram, StatementEmitter emitter)
+        public void ForwardDeclare(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.RecordTypeOverloads.ContainsKey(this))
                 return;
@@ -187,8 +188,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
                     if (!recordType.HasCopier)
                         emitter.AppendLine($"{recordType.GetCName(irProgram)} copy_record{recordType.GetStandardIdentifier(irProgram)}({recordType.GetCName(irProgram)} record, {RecordType.StandardRecordMask} parent_record);");
-                    if (!irProgram.EmitExpressionStatements)
-                        emitter.AppendLine($"{recordType.GetCName(irProgram)} move_record{recordType.GetStandardIdentifier(irProgram)}({recordType.GetCName(irProgram)}* dest, {recordType.GetCName(irProgram)} src, void* child_agent);");
                 }
             }
             else
@@ -204,8 +203,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
                 if (!genericRecordType.HasCopier)
                     emitter.AppendLine($"{genericRecordType.GetCName(irProgram)} copy_record{genericRecordType.GetStandardIdentifier(irProgram)}({genericRecordType.GetCName(irProgram)} record, {RecordType.StandardRecordMask} parent_record);");
-                if (!irProgram.EmitExpressionStatements)
-                    emitter.AppendLine($"{genericRecordType.GetCName(irProgram)} move_record{genericRecordType.GetStandardIdentifier(irProgram)}({genericRecordType.GetCName(irProgram)}* dest, {genericRecordType.GetCName(irProgram)} src, void* child_agent);");
 
                 foreach(RecordType recordType in irProgram.RecordTypeOverloads[this])
                 {
@@ -215,7 +212,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<TypeParameter, IType> typeargs, int indent)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs)
         {
             if (!irProgram.RecordTypeOverloads.ContainsKey(this))
                 return;
@@ -224,23 +221,21 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             {
                 foreach (RecordType recordType in irProgram.RecordTypeOverloads[this])
                 {
-                    recordType.EmitConstructor(irProgram, emitter);
-                    recordType.EmitDestructor(irProgram, emitter);
-                    recordType.EmitCopier(irProgram, emitter);
-                    recordType.EmitMover(irProgram, emitter);
-                    recordType.EmitBorrower(irProgram, emitter);
+                    recordType.EmitConstructor(irProgram, primaryEmitter);
+                    recordType.EmitDestructor(irProgram, primaryEmitter);
+                    recordType.EmitCopier(irProgram, primaryEmitter);
+                    recordType.EmitBorrower(irProgram, primaryEmitter);
                 }
             }
             else
             {
                 RecordType genericRecordType = irProgram.RecordTypeOverloads[this].First();
-                genericRecordType.EmitDestructor(irProgram, emitter);
-                genericRecordType.EmitCopier(irProgram, emitter);
-                genericRecordType.EmitMover(irProgram, emitter);
-                genericRecordType.EmitBorrower(irProgram, emitter);
+                genericRecordType.EmitDestructor(irProgram, primaryEmitter);
+                genericRecordType.EmitCopier(irProgram, primaryEmitter);
+                genericRecordType.EmitBorrower(irProgram, primaryEmitter);
 
                 foreach (RecordType recordType in irProgram.RecordTypeOverloads[this])
-                    recordType.EmitConstructor(irProgram, emitter);
+                    recordType.EmitConstructor(irProgram, primaryEmitter);
             }
         }
     }
@@ -274,14 +269,18 @@ namespace NoHoPython.Typing
         }
 
         public string GetStandardIdentifier(IRProgram irProgram) => RecordPrototype.EmitMultipleCStructs ? GetOriginalStandardIdentifer(irProgram) : $"nhp_record_{IScopeSymbol.GetAbsolouteName(RecordPrototype)}";
-        public string GetOriginalStandardIdentifer(IRProgram irProgram) => $"nhp_record_{IScopeSymbol.GetAbsolouteName(RecordPrototype)}_{string.Join('_', TypeArguments.ConvertAll((typearg) => typearg.GetStandardIdentifier(irProgram)))}_";
+        public string GetOriginalStandardIdentifer(IRProgram irProgram) => $"nhp_record_{IScopeSymbol.GetAbsolouteName(RecordPrototype)}_{string.Join('_', TypeArguments.ConvertAll((typearg) => typearg.GetStandardIdentifier(irProgram)))}";
 
         public string GetCName(IRProgram irProgram) => $"{GetStandardIdentifier(irProgram)}_t*";
         public string GetCHeapSizer(IRProgram irProgram) => $"sizeof({GetStandardIdentifier(irProgram)}_t)";
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent)
         {
-            emitter.Append($"free_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){childAgent}");
+            emitter.Append($"free_record{GetStandardIdentifier(irProgram)}(");
+            valuePromise(emitter);
+            emitter.Append($", ({StandardRecordMask})");
+            childAgent(emitter);
+
             if (destructorCall == null) 
             {
                 ITypeComparer comparer = new();
@@ -291,10 +290,10 @@ namespace NoHoPython.Typing
             }
             if (!RecordPrototype.EmitMultipleCStructs && destructorCall != null)
                 emitter.Append($", (nhp_custom_destructor)&{destructorCall.GetStandardIdentifier(irProgram)}");
-            emitter.Append(");");
+            emitter.AppendLine(");");
         }
 
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, Emitter primaryEmitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer)
         {
             if (copierCall == null)
             {
@@ -303,22 +302,26 @@ namespace NoHoPython.Typing
                 copierCall = irProgram.RecordTypeOverloads[RecordPrototype].Find((type) => comparer.Equals(type, this)).copierCall;
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
-            if (copierCall != null)
-                emitter.Append($"{copierCall.GetStandardIdentifier(irProgram)}({valueCSource}, {responsibleDestroyer})");
-            else
-                emitter.Append($"copy_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){responsibleDestroyer})");
+            primaryEmitter.Append(copierCall != null ? copierCall.GetStandardIdentifier(irProgram) : $"copy_record{GetStandardIdentifier(irProgram)}");
+            primaryEmitter.Append('(');
+            valueCSource(primaryEmitter);
+            primaryEmitter.Append(", ");
+            if (copierCall == null)
+                primaryEmitter.Append($"({StandardRecordMask})");
+            responsibleDestroyer(primaryEmitter);
+            primaryEmitter.Append(')');
         }
 
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
-        {
-            if (irProgram.EmitExpressionStatements)
-                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
-            else
-                emitter.Append($"move_record(&{destC}, {valueCSource}, {childAgent})");
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) 
+        { 
+            emitter.Append($"borrow_record{GetStandardIdentifier(irProgram)}(");
+            valueCSource(emitter);
+            emitter.Append($", ({StandardRecordMask})");
+            responsibleDestroyer(emitter);
+            emitter.Append(')');
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => emitter.Append($"borrow_record{GetStandardIdentifier(irProgram)}({valueCSource}, ({StandardRecordMask}){responsibleDestroyer})");
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise newRecord) => EmitCopyValue(irProgram, emitter, valueCSource, newRecord);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -337,7 +340,7 @@ namespace NoHoPython.Typing
             properties.Value.ForEach((property) => property.ScopeForUsedTypes(irBuilder));
         }
 
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this))
                 return;
@@ -351,7 +354,7 @@ namespace NoHoPython.Typing
             EmitCStructImmediatley(irProgram, emitter);
         }
         
-        public void EmitCStructImmediatley(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCStructImmediatley(IRProgram irProgram, Emitter emitter)
         {
             emitter.AppendLine($"struct {GetStandardIdentifier(irProgram)} {{");
             emitter.AppendLine("\tint nhp_ref_count;");
@@ -368,7 +371,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitConstructorCHeader(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitConstructorCHeader(IRProgram irProgram, Emitter emitter)
         {
             emitter.Append($"{GetCName(irProgram)} construct_{GetOriginalStandardIdentifer(irProgram)}(");
             for (int i = 0; i < constructorParameterTypes.Value.Count; i++)
@@ -376,7 +379,7 @@ namespace NoHoPython.Typing
             emitter.Append($"{StandardRecordMask} parent_record)");
         }
 
-        public void EmitConstructor(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitConstructor(IRProgram irProgram, Emitter emitter)
         {
             EmitConstructorCHeader(irProgram, emitter);
             emitter.AppendLine(" {"); 
@@ -390,14 +393,17 @@ namespace NoHoPython.Typing
             foreach (RecordDeclaration.RecordProperty recordProperty in properties.Value)
                 if (recordProperty.HasDefaultValue && !recordProperty.OptimizeMessageReciever)
                 {
-                    emitter.Append($"\tnhp_self->{recordProperty.Name} = ");
 #pragma warning disable CS8602 //recordProperty.HasDefaultValue guarentees DefaultValue is not null 
-                    if (recordProperty.DefaultValue.RequiresDisposal(new(), false))
-                        recordProperty.DefaultValue.Emit(irProgram, emitter, new(), "nhp_self", false);
-                    else
-                        recordProperty.Type.EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(recordProperty.DefaultValue, irProgram, new(), "NULL"), "nhp_self");
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
-                    emitter.AppendLine(";");
+                    recordProperty.DefaultValue.Emit(irProgram, emitter, typeargMap.Value, (valuePromise) =>
+                    {
+                        emitter.Append($"\tnhp_self->{recordProperty.Name} = ");
+                        if (recordProperty.DefaultValue.RequiresDisposal(irProgram, new(), false))
+                            valuePromise(emitter);
+                        else
+                            recordProperty.Type.EmitCopyValue(irProgram, emitter, valuePromise, (e) => e.Append("nhp_self"));
+                        emitter.AppendLine(';');
+                    }, (e) => e.Append("nhp_self"), false);
+#pragma warning restore CS8602 
                 }
 
             emitter.Append($"\t{constructorCall.GetStandardIdentifier(irProgram)}(");
@@ -409,7 +415,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitDestructor(IRProgram irProgram, Emitter emitter)
         {
             emitter.Append($"void free_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} record, {StandardRecordMask} child_agent");
             if (!RecordPrototype.EmitMultipleCStructs && destructorCall != null)
@@ -438,15 +444,15 @@ namespace NoHoPython.Typing
                 if (recordProperty.Type.RequiresDisposal && !recordProperty.OptimizeMessageReciever)
                 {
                     emitter.Append('\t');
-                    recordProperty.Type.EmitFreeValue(irProgram, emitter, $"record->{recordProperty.Name}", "record");
+                    recordProperty.Type.EmitFreeValue(irProgram, emitter, (e) => e.Append($"record->{recordProperty.Name}"), (e) => e.Append("record"));
                     emitter.AppendLine();
                 }
             }
-            emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("record", GetCHeapSizer(irProgram))};");
+            emitter.AppendLine($"\t{irProgram.MemoryAnalyzer.Dealloc("record", GetCHeapSizer(irProgram))}");
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCopier(IRProgram irProgram, Emitter emitter)
         {
             if (copierCall != null)
                 return;
@@ -463,7 +469,7 @@ namespace NoHoPython.Typing
                 if (!property.OptimizeMessageReciever)
                 {
                     emitter.Append($"\tcopied_record->{property.Name} = ");
-                    property.Type.EmitRecordCopyValue(irProgram, emitter, $"record->{property.Name}", "copied_record");
+                    property.Type.EmitRecordCopyValue(irProgram, emitter, (e) => e.Append($"record->{property.Name}"), (e) => e.Append("copied_record"));
                     emitter.AppendLine(";");
                 }
             }
@@ -472,21 +478,7 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
-        {
-            if (irProgram.EmitExpressionStatements)
-                return;
-
-            emitter.AppendLine($"{GetCName(irProgram)} move_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src, void* child_agent) {{");
-            emitter.Append('\t');
-            EmitFreeValue(irProgram, emitter, "*dest", "child_agent");
-            emitter.AppendLine();
-            emitter.AppendLine("\t*dest = src;");
-            emitter.AppendLine("\treturn src;");
-            emitter.AppendLine("}");
-        }
-
-        public void EmitBorrower(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitBorrower(IRProgram irProgram, Emitter emitter)
         {
             emitter.AppendLine($"{GetCName(irProgram)} borrow_record{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} record, void* responsible_destroyer) {{");
 

--- a/NoHoPython/Compilation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/Compilation/Statements/RecordDeclaration.cs
@@ -269,7 +269,7 @@ namespace NoHoPython.Typing
         }
 
         public string GetStandardIdentifier(IRProgram irProgram) => RecordPrototype.EmitMultipleCStructs ? GetOriginalStandardIdentifer(irProgram) : $"nhp_record_{IScopeSymbol.GetAbsolouteName(RecordPrototype)}";
-        public string GetOriginalStandardIdentifer(IRProgram irProgram) => $"nhp_record_{IScopeSymbol.GetAbsolouteName(RecordPrototype)}_{string.Join('_', TypeArguments.ConvertAll((typearg) => typearg.GetStandardIdentifier(irProgram)))}";
+        public string GetOriginalStandardIdentifer(IRProgram irProgram) => $"nhp_record_{IScopeSymbol.GetAbsolouteName(RecordPrototype)}{string.Join(string.Empty, TypeArguments.ConvertAll((typearg) => $"_{typearg.GetStandardIdentifier(irProgram)}"))}";
 
         public string GetCName(IRProgram irProgram) => $"{GetStandardIdentifier(irProgram)}_t*";
         public string GetCHeapSizer(IRProgram irProgram) => $"sizeof({GetStandardIdentifier(irProgram)}_t)";

--- a/NoHoPython/Compilation/Statements/TupleType.cs
+++ b/NoHoPython/Compilation/Statements/TupleType.cs
@@ -109,7 +109,7 @@ namespace NoHoPython.Typing
             if (RequiresDisposal)
             {
                 int indirection = emitter.AppendStartBlock();
-                emitter.Append($"\t{GetCName(irProgram)}to_free{indirection} = ");
+                emitter.Append($"{GetCName(irProgram)} to_free{indirection} = ");
                 valuePromise(emitter);
                 emitter.AppendLine(";");
 
@@ -117,10 +117,7 @@ namespace NoHoPython.Typing
                 {
                     if (valuePair.Key.RequiresDisposal)
                         for (int i = 0; i < valuePair.Value; i++)
-                        {
                             valuePair.Key.EmitFreeValue(irProgram, emitter, (e) => e.Append($"to_free{indirection}.{valuePair.Key.Identifier}{i}"), childAgent);
-                            emitter.AppendLine();
-                        }
                 }
                 emitter.AppendEndBlock();
             }

--- a/NoHoPython/Compilation/Statements/TupleType.cs
+++ b/NoHoPython/Compilation/Statements/TupleType.cs
@@ -29,38 +29,38 @@ namespace NoHoPython.IntermediateRepresentation
     {
         private List<TupleType> usedTupleTypes;
 
-        private void EmitTupleTypeTypedefs(StatementEmitter emitter)
+        private void EmitTupleTypeTypedefs(Emitter emitter)
         {
             foreach(TupleType usedTupleType in usedTupleTypes)
                 emitter.AppendLine($"typedef struct {usedTupleType.GetStandardIdentifier(this)} {usedTupleType.GetCName(this)};");
         }
 
-        private void EmitTupleCStructs(StatementEmitter emitter)
+        private void EmitTupleCStructs(Emitter emitter)
         {
             foreach(TupleType usedTupleType in usedTupleTypes)
                 usedTupleType.EmitCStruct(this, emitter);
         }
 
-        private void ForwardDeclareTupleTypes(StatementEmitter emitter)
+        private void ForwardDeclareTupleTypes(Emitter emitter)
         {
             foreach(TupleType usedTupleType in usedTupleTypes)
             {
-                usedTupleType.EmitDestructorHeader(this, emitter);
-                emitter.AppendLine(";");
-                usedTupleType.EmitMoverHeader(this, emitter);
+                if (!usedTupleType.RequiresDisposal)
+                    continue;
+
+                usedTupleType.EmitCopierHeader(this, emitter);
                 emitter.AppendLine(";");
             }
         }
 
-        private void EmitTupleTypeMarshallers(StatementEmitter emitter)
+        private void EmitTupleTypeMarshallers(Emitter emitter)
         {
             foreach (TupleType usedTupleType in usedTupleTypes)
             {
                 if (!usedTupleType.RequiresDisposal)
                     continue;
 
-                usedTupleType.EmitDestructor(this, emitter);
-                usedTupleType.EmitMover(this, emitter);
+                usedTupleType.EmitCopier(this, emitter);
             }
         }
     }
@@ -74,15 +74,15 @@ namespace NoHoPython.Typing
         {
             public override bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs) => false;
 
-            public override bool EmitGet(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, IPropertyContainer propertyContainer, string valueCSource, string responsibleDestroyer)
+            public override bool EmitGet(IRProgram irProgram, Emitter emitter, Dictionary<TypeParameter, IType> typeargs, IPropertyContainer propertyContainer, Emitter.Promise value, Emitter.Promise responsibleDestroyer)
             {
                 Debug.Assert(propertyContainer is TupleType);
 
                 IType realPropertyType = Type.SubstituteWithTypearg(typeargs);
                 Debug.Assert(realPropertyType is not TypeParameterReference);
 
-                emitter.Append($"{valueCSource}.{realPropertyType.Identifier}{TypeNumber}");
-
+                value(emitter);
+                emitter.Append($".{realPropertyType.Identifier}{TypeNumber}");
                 return false;
             }
         }
@@ -104,62 +104,47 @@ namespace NoHoPython.Typing
         public string GetStandardIdentifier(IRProgram irProgram) => $"nhp_tuple_{Identifier}";
         public string GetCName(IRProgram irProgram) => $"{GetStandardIdentifier(irProgram)}_t";
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent)
         {
             if (RequiresDisposal)
             {
-                emitter.Append($"free_{GetStandardIdentifier(irProgram)}({valueCSource}");
-                if (MustSetResponsibleDestroyer)
-                    emitter.Append($", {childAgent}");
-                emitter.Append(");");
-            }
-        }
+                int indirection = emitter.AppendStartBlock();
+                emitter.Append($"\t{GetCName(irProgram)}to_free{indirection} = ");
+                valuePromise(emitter);
+                emitter.AppendLine(";");
 
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
-        {
-            if (RequiresDisposal)
-            {
-                emitter.Append($"({GetCName(irProgram)}){{");
-
-                bool emitCommaSeparator = false;
                 foreach (KeyValuePair<IType, int> valuePair in ValueTypes)
                 {
-                    for (int i = 0; i < valuePair.Value; i++)
-                    {
-                        if (emitCommaSeparator)
-                            emitter.Append(", ");
-                        else
-                            emitCommaSeparator = true;
-
-                        emitter.Append($".{valuePair.Key.Identifier}{i} = ");
-                        valuePair.Key.EmitCopyValue(irProgram, emitter, $"{valueCSource}.{valuePair.Key.Identifier}{i}", responsibleDestroyer);
-                    }
+                    if (valuePair.Key.RequiresDisposal)
+                        for (int i = 0; i < valuePair.Value; i++)
+                        {
+                            valuePair.Key.EmitFreeValue(irProgram, emitter, (e) => e.Append($"to_free{indirection}.{valuePair.Key.Identifier}{i}"), childAgent);
+                            emitter.AppendLine();
+                        }
                 }
-                emitter.Append('}');
+                emitter.AppendEndBlock();
             }
-            else
-                emitter.Append(valueCSource);
         }
 
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
+        public void EmitCopyValue(IRProgram irProgram, Emitter primaryEmitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer)
         {
             if (RequiresDisposal)
             {
-                if (irProgram.EmitExpressionStatements)
-                    IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
-                else
+                primaryEmitter.Append($"copy_{GetStandardIdentifier(irProgram)}(");
+                valueCSource(primaryEmitter);
+                if (MustSetResponsibleDestroyer)
                 {
-                    emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}");
-                    if (MustSetResponsibleDestroyer)
-                        emitter.Append($", {childAgent})");
+                    primaryEmitter.Append(", ");
+                    responsibleDestroyer(primaryEmitter);
                 }
-            }
+                primaryEmitter.Append(')');
+            }    
             else
-                emitter.Append($"({destC} = {valueCSource})");
+                valueCSource(primaryEmitter);
         }
 
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise newRecord) => EmitCopyValue(irProgram, emitter, valueCSource, newRecord);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -170,7 +155,7 @@ namespace NoHoPython.Typing
             }
         }
 
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this))
                 return;
@@ -184,56 +169,29 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitDestructorHeader(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCopierHeader(IRProgram irProgram, Emitter emitter)
         {
-            emitter.Append($"void free_{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} to_free");
+            emitter.Append($"{GetCName(irProgram)} copy_{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} to_copy");
             if (MustSetResponsibleDestroyer)
-                emitter.Append(", void* child_agent");
+                emitter.Append(", void* responsible_destroyer");
             emitter.Append(')');
         }
 
-        public void EmitMoverHeader(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCopier(IRProgram irProgram, Emitter emitter)
         {
-            emitter.Append($"{GetCName(irProgram)} move{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src");
-            if (MustSetResponsibleDestroyer)
-                emitter.Append(", void* child_agent");
-            emitter.Append(')');
-        }
-
-        public void EmitDestructor(IRProgram irProgram, StatementEmitter emitter)
-        {
-            EmitDestructorHeader(irProgram, emitter);
+            EmitCopierHeader(irProgram, emitter);
             emitter.AppendLine(" {");
-
+            emitter.AppendLine($"\t{GetCName(irProgram)} to_ret;");
             foreach (KeyValuePair<IType, int> valuePair in ValueTypes)
             {
-                if (valuePair.Key.RequiresDisposal) {
-                    for (int i = 0; i < valuePair.Value; i++)
-                    {
-                        emitter.Append('\t');
-                        valuePair.Key.EmitFreeValue(irProgram, emitter, $"to_free.{valuePair.Key.Identifier}{i}", "child_agent");
-                        emitter.AppendLine();
-                    }
+                for (int i = 0; i < valuePair.Value; i++)
+                {
+                    emitter.Append($"\tto_ret.{valuePair.Key.Identifier}{i} = ");
+                    valuePair.Key.EmitCopyValue(irProgram, emitter, (e) => e.Append($"to_copy.{valuePair.Key.Identifier}{i}"), (e) => e.Append("responsible_destroyer"));
+                    emitter.AppendLine(";");
                 }
             }
-
-            emitter.AppendLine("}");
-        }
-
-        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
-        {
-            if (irProgram.EmitExpressionStatements)
-                return;
-
-            EmitMoverHeader(irProgram, emitter);
-            emitter.AppendLine("{");
-            emitter.Append("\t");
-            EmitFreeValue(irProgram, emitter, "*dest", "child_agent");
-            emitter.AppendLine();
-            emitter.Append("\t*dest = ");
-            EmitCopyValue(irProgram, emitter, "src", "child_agent");
-            emitter.AppendLine(";");
-            emitter.AppendLine("\treturn src;");
+            emitter.AppendLine("\treturn to_ret;");
             emitter.AppendLine("}");
         }
     }

--- a/NoHoPython/Compilation/Types/Arrays.cs
+++ b/NoHoPython/Compilation/Types/Arrays.cs
@@ -35,34 +35,26 @@ namespace NoHoPython.IntermediateRepresentation
         private List<ArrayType> usedArrayTypes;
         private List<IType> bufferTypes;
 
-        public void EmitArrayTypeTypedefs(StatementEmitter emitter)
+        public void EmitArrayTypeTypedefs(Emitter emitter)
         {
             foreach (ArrayType arrayType in usedArrayTypes)
                 emitter.AppendLine($"typedef struct {arrayType.GetStandardIdentifier(this)} {arrayType.GetCName(this)};");
         }
 
-        public void EmitArrayTypeCStructs(StatementEmitter emitter)
+        public void EmitArrayTypeCStructs(Emitter emitter)
         {
             foreach (ArrayType arrayType in usedArrayTypes)
                 arrayType.EmitCStruct(this, emitter);
         }
 
-        public void ForwardDeclareArrayTypes(StatementEmitter emitter)
+        public void ForwardDeclareArrayTypes(Emitter emitter)
         {
             foreach (ArrayType arrayType in usedArrayTypes)
             {
-                emitter.Append($"{arrayType.GetCName(this)} marshal{arrayType.GetStandardIdentifier(this)}({arrayType.ElementType.GetCName(this)}* buffer, int length");
-                if (arrayType.MustSetResponsibleDestroyer)
-                    emitter.Append(", void* responsible_destroyer");
-                emitter.AppendLine(");");
-
                 emitter.Append($"{arrayType.GetCName(this)} marshal_proto{arrayType.GetStandardIdentifier(this)}(int length, {arrayType.ElementType.GetCName(this)} proto");
                 if (arrayType.MustSetResponsibleDestroyer)
                     emitter.Append(", void* responsible_destroyer");
                 emitter.AppendLine(");");
-
-                if (!EmitExpressionStatements)
-                    emitter.AppendLine($"{arrayType.GetCName(this)} move{arrayType.GetStandardIdentifier(this)}({arrayType.GetCName(this)}* src, {arrayType.GetCName(this)} dest, void* child_agent);");
 
                 if (arrayType.ElementType.RequiresDisposal)
                 {
@@ -74,17 +66,17 @@ namespace NoHoPython.IntermediateRepresentation
             }
         }
 
-        public void EmitArrayTypeMarshallers(StatementEmitter emitter, bool doCallStack)
+        public void EmitArrayTypeMarshallers(Emitter emitter)
         {
             if (DoBoundsChecking)
             {
                 emitter.AppendLine("int nhp_bounds_check(int index, int max_length, const char* src_loc, const char* access_src) {");
                 emitter.AppendLine("\tif(index < 0 || index >= max_length) {");
 
-                if (doCallStack)
+                if (DoCallStack)
                 {
-                    CallStackReporting.EmitErrorLoc(emitter, "src_loc", "access_src", 2);
-                    CallStackReporting.EmitPrintStackTrace(emitter, 2);
+                    CallStackReporting.EmitErrorLoc(emitter, "src_loc", "access_src");
+                    CallStackReporting.EmitPrintStackTrace(emitter);
                     emitter.AppendLine("\t\tprintf(\"IndexError: Index was %i, length was %i.\\n\", index, max_length);");
                 }
                 else
@@ -102,12 +94,11 @@ namespace NoHoPython.IntermediateRepresentation
             foreach (ArrayType arrayType in usedArrayTypes)
             {
                 arrayType.EmitMarshaller(this, emitter);
-                arrayType.EmitMover(this, emitter);
                 arrayType.EmitCopier(this, emitter);
             }
         }
 
-        private void EmitBufferCopiers(StatementEmitter emitter)
+        private void EmitBufferCopiers(Emitter emitter)
         {
             foreach(IType elementType in bufferTypes)
             {
@@ -121,7 +112,7 @@ namespace NoHoPython.IntermediateRepresentation
                     emitter.AppendLine($"\t{elementType.GetCName(this)}* buf = {MemoryAnalyzer.Allocate($"sizeof({elementType.GetCName(this)}) * len")};");
                     emitter.AppendLine("\tfor(int i = 0; i < len; i++) {");
                     emitter.Append("\t\tbuf[i] = ");
-                    elementType.EmitCopyValue(this, emitter, "src[i]", "responsible_destroyer");
+                    elementType.EmitCopyValue(this, emitter, (e) => e.Append("src[i]"), (e) => e.Append("responsible_destroyer"));
                     emitter.AppendLine(";");
                     emitter.AppendLine("\t}");
                     emitter.AppendLine("\treturn buf;");
@@ -135,14 +126,14 @@ namespace NoHoPython.IntermediateRepresentation
                 emitter.AppendLine($"\t{elementType.GetCName(this)}* buf = {MemoryAnalyzer.Allocate($"count * sizeof({elementType.GetCName(this)})")};");
                 emitter.AppendLine("\tfor(int i = 0; i < count; i++) {");
                 emitter.Append("\t\tbuf[i] = ");
-                elementType.EmitCopyValue(this, emitter, "proto", "responsible_destroyer");
+                elementType.EmitCopyValue(this, emitter, (e) => e.Append("proto"), (e) => e.Append("responsible_destroyer"));
                 emitter.AppendLine(";");
                 emitter.AppendLine("\t}");
 
                 if (elementType.RequiresDisposal)
                 {
                     emitter.Append('\t');
-                    elementType.EmitFreeValue(this, emitter, "proto", "NULL");
+                    elementType.EmitFreeValue(this, emitter, (e) => e.Append("proto"), Emitter.NullPromise);
                     emitter.AppendLine();
                 }
 
@@ -164,41 +155,35 @@ namespace NoHoPython.Typing
 
         public bool TypeParameterAffectsCodegen(Dictionary<IType, bool> effectInfo) => true;
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent)
         {
+            int indirection = emitter.AppendStartBlock();
+            emitter.Append($"\t{GetCName(irProgram)} to_free{indirection} = ");
+            valuePromise(emitter);
+            emitter.AppendLine(";");
             if(ElementType.RequiresDisposal)
             {
-                emitter.Append($"for(int free_i = 0; free_i < {valueCSource}.length; free_i++) {{ ");
-                ElementType.EmitFreeValue(irProgram, emitter, $"{valueCSource}.buffer[free_i]", childAgent);
-                emitter.Append("}; ");
+                emitter.AppendStartBlock($"for(int i = 0; i < to_free{indirection}.length; i++)");
+                ElementType.EmitFreeValue(irProgram, emitter, (e) => e.Append($"to_free{indirection}.buffer[i]"), childAgent);
+                emitter.AppendEndBlock();
             }
-
-            emitter.Append($"{irProgram.MemoryAnalyzer.Dealloc($"{valueCSource}.buffer", $"{valueCSource}.length * sizeof({ElementType.GetCName(irProgram)})")};");
+            emitter.AppendLine($"{irProgram.MemoryAnalyzer.Dealloc($"to_free{indirection}.buffer", $"to_free{indirection}.length * sizeof({ElementType.GetCName(irProgram)})")}");
+            emitter.AppendEndBlock();
         }
 
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, Emitter primaryEmitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer)
         {
-            if (ElementType.RequiresDisposal)
-                emitter.Append($"copy{GetStandardIdentifier(irProgram)}({valueCSource}");
-            else
-                emitter.Append($"marshal{GetStandardIdentifier(irProgram)}({valueCSource}.buffer, {valueCSource}.length");
+            primaryEmitter.Append($"copy{GetStandardIdentifier(irProgram)}(");
+            valueCSource(primaryEmitter);
 
             if (MustSetResponsibleDestroyer)
-                emitter.Append($", {responsibleDestroyer}");
+                primaryEmitter.Append($", {responsibleDestroyer}");
 
-            emitter.Append(')');
+            primaryEmitter.Append(')');
         }
 
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent)
-        {
-            if (irProgram.EmitExpressionStatements)
-                IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
-            else
-                emitter.Append($"move{GetStandardIdentifier(irProgram)}(&{destC}, {valueCSource}, {childAgent})");
-        }
-
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise newRecord) => EmitCopyValue(irProgram, emitter, valueCSource, newRecord);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -210,7 +195,7 @@ namespace NoHoPython.Typing
 
         public string GetStandardIdentifier(IRProgram irProgram) => $"nhp_array_{ElementType.GetStandardIdentifier(irProgram)}";
 
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter)
         {
             if (!irProgram.DeclareCompiledType(emitter, this))
                 return;
@@ -221,22 +206,8 @@ namespace NoHoPython.Typing
             emitter.AppendLine("};");
         }
 
-        public void EmitMarshaller(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitMarshaller(IRProgram irProgram, Emitter emitter)
         {
-            emitter.Append($"{GetCName(irProgram)} marshal{GetStandardIdentifier(irProgram)}({ElementType.GetCName(irProgram)}* buffer, int length");
-
-            if (MustSetResponsibleDestroyer)
-                emitter.Append(", void* responsible_destroyer");
-
-            emitter.AppendLine(") {");
-            emitter.AppendLine($"\t{GetCName(irProgram)} to_alloc;");
-            emitter.AppendLine($"\tto_alloc.buffer = {irProgram.MemoryAnalyzer.Allocate($"length * sizeof({ElementType.GetCName(irProgram)})")};");
-            emitter.AppendLine($"\tmemcpy(to_alloc.buffer, buffer, length * sizeof({ElementType.GetCName(irProgram)}));");
-            emitter.AppendLine("\tto_alloc.length = length;");
-            
-            emitter.AppendLine("\treturn to_alloc;");
-            emitter.AppendLine("}");
-
             if (ElementType.RequiresDisposal)
             {
                 emitter.Append($"{GetCName(irProgram)} marshal_foreign{GetStandardIdentifier(irProgram)}({ElementType.GetCName(irProgram)}* buffer, int length");
@@ -275,11 +246,8 @@ namespace NoHoPython.Typing
             emitter.AppendLine("}");
         }
 
-        public void EmitCopier(IRProgram irProgram, StatementEmitter emitter)
+        public void EmitCopier(IRProgram irProgram, Emitter emitter)
         {
-            if (!ElementType.RequiresDisposal)
-                return;
-
             emitter.Append($"{GetCName(irProgram)} copy{GetStandardIdentifier(irProgram)}({GetCName(irProgram)} to_copy");
 
             if (MustSetResponsibleDestroyer)
@@ -287,28 +255,22 @@ namespace NoHoPython.Typing
 
             emitter.AppendLine(") {");
             emitter.AppendLine($"\t{GetCName(irProgram)} copied;");
-            
-            emitter.Append($"\tcopied.buffer = buffer_copy_{ElementType.GetStandardIdentifier(irProgram)}(to_copy.buffer, to_copy.length");
-            if(MustSetResponsibleDestroyer)
-                emitter.Append(", responsible_destroyer");
-            emitter.AppendLine(");");
+
+            if (ElementType.RequiresDisposal)
+            {
+                emitter.Append($"\tcopied.buffer = buffer_copy_{ElementType.GetStandardIdentifier(irProgram)}(to_copy.buffer, to_copy.length");
+                if (MustSetResponsibleDestroyer)
+                    emitter.Append(", responsible_destroyer");
+                emitter.AppendLine(");");
+            }
+            else
+            {
+                string sizeSrc = $"to_copy.length * sizeof({ElementType.GetCName(irProgram)})";
+                emitter.AppendLine($"\tcopied.buffer = memcpy({irProgram.MemoryAnalyzer.Allocate(sizeSrc)}, to_copy.buffer, {sizeSrc});");
+            }
 
             emitter.AppendLine("\tcopied.length = to_copy.length;");
             emitter.AppendLine("\treturn copied;");
-            emitter.AppendLine("}");
-        }
-
-        public void EmitMover(IRProgram irProgram, StatementEmitter emitter)
-        {
-            if (irProgram.EmitExpressionStatements)
-                return;
-
-            emitter.AppendLine($"{GetCName(irProgram)} move{GetStandardIdentifier(irProgram)}({GetCName(irProgram)}* dest, {GetCName(irProgram)} src, void* child_agent) {{");
-            emitter.Append('\t');
-            EmitFreeValue(irProgram, emitter, "(*dest)", "child_agent");
-            emitter.AppendLine();
-            emitter.AppendLine("\t*dest = src;");
-            emitter.AppendLine("\treturn src;");
             emitter.AppendLine("}");
         }
     }
@@ -326,38 +288,53 @@ namespace NoHoPython.Typing
 
         public string GetStandardIdentifier(IRProgram irProgram) => $"nhp_{Identifier}";
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent)
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent)
         {
             if (ElementType.RequiresDisposal)
             {
-                emitter.Append($"for(int free_i = 0; free_i < {Length}; free_i++) {{ ");
-                ElementType.EmitFreeValue(irProgram, emitter, $"{valueCSource}[free_i]", childAgent);
-                emitter.Append("}; ");
+                int indirection = emitter.AppendStartBlock();
+                emitter.Append($"\t{GetCName(irProgram)} to_free{indirection} = ");
+                valuePromise(emitter);
+                emitter.AppendLine(";");
+                emitter.AppendStartBlock($"for(int i = 0; i < to_free{indirection}.length; i++)");
+                ElementType.EmitFreeValue(irProgram, emitter, (e) => e.Append($"to_free{indirection}.buffer[i]"), childAgent);
+                emitter.AppendEndBlock();
+                emitter.Append($"{irProgram.MemoryAnalyzer.Dealloc($"to_free{indirection}.buffer", $"to_free{indirection}.length * sizeof({ElementType.GetCName(irProgram)})")};");
+                emitter.AppendEndBlock();
             }
-
-            emitter.Append($"{irProgram.MemoryAnalyzer.Dealloc($"{valueCSource}", $"{Length} * sizeof({ElementType.GetCName(irProgram)})")};");
+            else
+                using(Emitter valueSrcBuffer = new Emitter())
+                {
+                    valuePromise(valueSrcBuffer);
+                    emitter.Append($"{irProgram.MemoryAnalyzer.Dealloc(valueSrcBuffer.GetBuffered(), $"{Length} * sizeof({ElementType.GetCName(irProgram)})")}");
+                }
         }
 
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer)
+        public void EmitCopyValue(IRProgram irProgram, Emitter primaryEmitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer)
         {
             if (ElementType.RequiresDisposal)
             {
-                emitter.Append($"buffer_copy_{ElementType.GetStandardIdentifier(irProgram)}({valueCSource}, {Length}");
+                primaryEmitter.Append($"buffer_copy_{ElementType.GetStandardIdentifier(irProgram)}(");
+                valueCSource(primaryEmitter);
+                primaryEmitter.Append($", {Length}");
                 if (ElementType.MustSetResponsibleDestroyer)
-                    emitter.Append($", {responsibleDestroyer}");
-                emitter.Append(')');
+                {
+                    primaryEmitter.Append(", ");
+                    responsibleDestroyer(primaryEmitter);
+                }
+                primaryEmitter.Append(')');
             }
             else
             {
-                string size = $"{Length} * sizeof({ElementType.GetCName(irProgram)})";
-                emitter.Append($"memcpy({irProgram.MemoryAnalyzer.Allocate(size)}, {valueCSource}, {size})");
+                string sizeSrc = $"{Length} * sizeof({ElementType.GetCName(irProgram)})";
+                primaryEmitter.Append($"memcpy({irProgram.MemoryAnalyzer.Allocate(sizeSrc)}, ");
+                valueCSource(primaryEmitter);
+                primaryEmitter.Append($", {sizeSrc})");
             }
         }
-
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => IType.EmitMove(this, irProgram, emitter, destC, valueCSource, childAgent);
-
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource) => EmitCopyValue(irProgram, emitter, valueCSource, newRecordCSource);
+         
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) => EmitCopyValue(irProgram, emitter, valueCSource, responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise newRecord) => EmitCopyValue(irProgram, emitter, valueCSource, newRecord);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -365,6 +342,6 @@ namespace NoHoPython.Typing
             irBuilder.ScopeForUsedBufferType(ElementType);
         }
 
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) { }
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter) { }
     }
 }

--- a/NoHoPython/Compilation/Types/Arrays.cs
+++ b/NoHoPython/Compilation/Types/Arrays.cs
@@ -158,7 +158,7 @@ namespace NoHoPython.Typing
         public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent)
         {
             int indirection = emitter.AppendStartBlock();
-            emitter.Append($"\t{GetCName(irProgram)} to_free{indirection} = ");
+            emitter.Append($"{GetCName(irProgram)} to_free{indirection} = ");
             valuePromise(emitter);
             emitter.AppendLine(";");
             if(ElementType.RequiresDisposal)

--- a/NoHoPython/Compilation/Types/TypeParameters.cs
+++ b/NoHoPython/Compilation/Types/TypeParameters.cs
@@ -23,10 +23,10 @@ namespace NoHoPython.Typing
                 UnderlyingTypeargumentProperty.ScopeForUse(optimizedMessageRecieverCall, typeargs, irBuilder);
             }
 
-            public override bool EmitGet(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, IPropertyContainer propertyContainer, string valueCSource, string responsibleDestroyer)
+            public override bool EmitGet(IRProgram irProgram, Emitter emitter, Dictionary<TypeParameter, IType> typeargs, IPropertyContainer propertyContainer, Emitter.Promise value, Emitter.Promise responsibleDestroyer)
             {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-                return UnderlyingTypeargumentProperty.EmitGet(irProgram, emitter, typeargs, propertyContainer, valueCSource, responsibleDestroyer);
+                return UnderlyingTypeargumentProperty.EmitGet(irProgram, emitter, typeargs, propertyContainer, value, responsibleDestroyer);
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
         }
@@ -43,12 +43,11 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public string GetStandardIdentifier(IRProgram irProgram) => $"type_param_{TypeParameter.Name}";
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string recordCSource) => throw new UnexpectedTypeParameterError(TypeParameter, null);
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer)=> throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer) => throw new UnexpectedTypeParameterError(TypeParameter, null);
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter) => throw new UnexpectedTypeParameterError(TypeParameter, null);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder) => throw new UnexpectedTypeParameterError(TypeParameter, null);
     }

--- a/NoHoPython/Compilation/Types/TypeParameters.cs
+++ b/NoHoPython/Compilation/Types/TypeParameters.cs
@@ -38,7 +38,7 @@ namespace NoHoPython.Typing
 
         public bool TypeParameterAffectsCodegen(Dictionary<IType, bool> effectInfo) => true;
 
-        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
+        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement, Syntax.AstIRProgramBuilder irBuilder) => throw new NoDefaultValueError(this, errorReportedElement);
 
         public string GetCName(IRProgram irProgram) => throw new UnexpectedTypeParameterError(TypeParameter, null);
         public string GetStandardIdentifier(IRProgram irProgram) => $"type_param_{TypeParameter.Name}";

--- a/NoHoPython/Compilation/Values/Arithmetic.cs
+++ b/NoHoPython/Compilation/Values/Arithmetic.cs
@@ -4,7 +4,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 {
     partial class ArithmeticCast
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) 
         {
@@ -12,12 +12,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Input.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Input.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) =>
         {
             void EmitCCast(string castTo)
             {
                 emitter.Append($"(({castTo})");
-                IRValue.EmitMemorySafe(Input, irProgram, emitter, typeargs);
+                IRValue.EmitDirect(irProgram, emitter, Input, typeargs, Emitter.NullPromise, true);
                 emitter.Append(')');
             }
 
@@ -25,7 +27,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             {
                 case ArithmeticCastOperation.BooleanToInt:
                 case ArithmeticCastOperation.CharToInt:
-                    IRValue.EmitMemorySafe(Input, irProgram, emitter, typeargs);
+                    IRValue.EmitDirect(irProgram, emitter, Input, typeargs, Emitter.NullPromise, true);
                     break;
                 case ArithmeticCastOperation.HandleToInt:
                 case ArithmeticCastOperation.DecimalToInt:
@@ -39,7 +41,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     break;
                 case ArithmeticCastOperation.IntToBoolean:
                     emitter.Append('(');
-                    IRValue.EmitMemorySafe(Input, irProgram, emitter, typeargs);
+                    IRValue.EmitDirect(irProgram, emitter, Input, typeargs, Emitter.NullPromise, isTemporaryEval);
                     emitter.Append(" ? 1 : 0");
                     emitter.Append(')');
                     break;
@@ -47,12 +49,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     EmitCCast("void*");
                     break;
             }
-        }
+        });
     }
 
     partial class HandleCast
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Input.RequiresDisposal(typeargs, isTemporaryEval);
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Input.RequiresDisposal(irProgram, typeargs, isTemporaryEval);
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -60,61 +62,74 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Input.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Input.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) =>
         {
             emitter.Append($"(({TargetHandleType.GetCName(irProgram)})");
-            Input.Emit(irProgram, emitter, typeargs, responsibleDestroyer, isTemporaryEval);
+            IRValue.EmitDirect(irProgram, emitter, Input, typeargs, Emitter.NullPromise, isTemporaryEval);
             emitter.Append(')');
-        }
+        });
     }
 
     partial class ArithmeticOperator
     {
-        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource)
+        protected override void EmitExpression(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise left, Emitter.Promise right)
         {
-            if (Operation == ArithmeticOperation.Exponentiate)
+            if(Operation == ArithmeticOperation.Exponentiate)
             {
-                if (Type is DecimalType)
-                    emitter.Append($"pow({leftCSource}, {rightCSource})");
-                else
-                    emitter.Append($"(int)pow((double){leftCSource}, (double){rightCSource})");
+                if (Type is not DecimalType)
+                    primaryEmitter.Append("(int)");
+                primaryEmitter.Append("pow(");
+                left(primaryEmitter);
+                primaryEmitter.Append(", ");
+                right(primaryEmitter);
+                primaryEmitter.Append(')');
             }
-            else if (Operation == ArithmeticOperation.Modulo && Type is DecimalType)
-                emitter.Append($"fmod({leftCSource}, {rightCSource})");
+            else if(Operation == ArithmeticOperation.Modulo && Type is DecimalType)
+            {
+                primaryEmitter.Append("fmod(");
+                left(primaryEmitter);
+                primaryEmitter.Append(", ");
+                right(primaryEmitter);
+                primaryEmitter.Append(')');
+            }
             else
             {
-                emitter.Append($"({leftCSource}");
-                switch (Operation)
+                primaryEmitter.Append('(');
+                left(primaryEmitter);
+                primaryEmitter.Append(Operation switch
                 {
-                    case ArithmeticOperation.Add:
-                        emitter.Append(" + ");
-                        break;
-                    case ArithmeticOperation.Subtract:
-                        emitter.Append(" - ");
-                        break;
-                    case ArithmeticOperation.Multiply:
-                        emitter.Append(" * ");
-                        break;
-                    case ArithmeticOperation.Divide:
-                        emitter.Append(" / ");
-                        break;
-					case ArithmeticOperation.Modulo:
-						emitter.Append(" % ");
-						break;
-                }
-                emitter.Append($"{rightCSource})");
+                    ArithmeticOperation.Add => " + ",
+                    ArithmeticOperation.Subtract => " - ",
+                    ArithmeticOperation.Multiply => " * ",
+                    ArithmeticOperation.Divide => " / ",
+                    ArithmeticOperation.Modulo => " % ",
+                    _ => throw new InvalidOperationException()
+                });
+                right(primaryEmitter);
+                primaryEmitter.Append(')');
             }
         }
     }
 
     partial class PointerAddOperator
     {
-        public override void EmitExpression(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string leftCSource, string rightCSource) => emitter.Append($"&{leftCSource}[{rightCSource}]");
+        protected override void EmitExpression(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.Promise left, Emitter.Promise right)
+        {
+            primaryEmitter.Append('(');
+            left(primaryEmitter);
+            primaryEmitter.Append(" + ");
+            right(primaryEmitter);
+            primaryEmitter.Append(')');
+        }
     }
 
     partial class ArrayOperator
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => ArrayValue.MustUseDestinationPromise(irProgram, typeargs, true) || ArrayValue.RequiresDisposal(irProgram, typeargs, true);
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
         {
@@ -122,39 +137,46 @@ namespace NoHoPython.IntermediateRepresentation.Values
             ArrayValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            void EmitOp()
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
-                switch (Operation)
-                {
-                    case ArrayOperation.GetArrayLength:
-                        emitter.Append(".length");
-                        break;
-                    case ArrayOperation.GetArrayHandle:
-                        emitter.Append(".buffer");
-                        break;
-                }
-            }
+                int indirection = primaryEmitter.AppendStartBlock();
 
-            if(ArrayValue.RequiresDisposal(typeargs, false))
-            {
-                if (!irProgram.EmitExpressionStatements || Operation == ArrayOperation.GetArrayHandle || Operation == ArrayOperation.GetSpanHandle)
+                primaryEmitter.AppendLine($"{ArrayValue.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} arr{indirection};");
+                ArrayValue.Emit(irProgram, primaryEmitter, typeargs, (arrayPromise) =>
+                {
+                    primaryEmitter.Append($"arr{indirection} = ");
+                    arrayPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+
+                if (Operation != ArrayOperation.GetArrayLength && ArrayValue.RequiresDisposal(irProgram, typeargs, true))
                     throw new CannotEmitDestructorError(ArrayValue);
 
-                emitter.Append($"({{{ArrayValue.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} nhp_buffer = ");
-                ArrayValue.Emit(irProgram, emitter, typeargs, "NULL", false);
-                emitter.Append($"; {Type.GetCName(irProgram)} nhp_res = nhp_buffer");
-                EmitOp();
-                emitter.Append("; ");
-                ArrayValue.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, emitter, "nhp_buffer", "NULL");
-                emitter.Append("; nhp_res;})");
+                destination((emitter) =>
+                {
+                    emitter.Append($"arr{indirection}");
+                    if (Operation == ArrayOperation.GetArrayLength)
+                        emitter.Append(".length");
+                    else if (Operation == ArrayOperation.GetArrayHandle)
+                        emitter.Append(".buffer");
+                });
+
+                if (ArrayValue.RequiresDisposal(irProgram, typeargs, true))
+                    ArrayValue.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"arr{indirection}"), Emitter.NullPromise);
+
+                primaryEmitter.AppendEndBlock();
             }
             else
-            {
-                ArrayValue.Emit(irProgram, emitter, typeargs, "NULL", false);
-                EmitOp();
-            }
+                destination((emitter) =>
+                {
+                    IRValue.EmitDirect(irProgram, emitter, ArrayValue, typeargs, Emitter.NullPromise, true);
+                    if (Operation == ArrayOperation.GetArrayLength)
+                        emitter.Append(".length");
+                    else if (Operation == ArrayOperation.GetArrayHandle)
+                        emitter.Append(".buffer");
+                });
         }
     }
 }

--- a/NoHoPython/Compilation/Values/Arithmetic.cs
+++ b/NoHoPython/Compilation/Values/Arithmetic.cs
@@ -144,12 +144,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 int indirection = primaryEmitter.AppendStartBlock();
 
                 primaryEmitter.AppendLine($"{ArrayValue.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} arr{indirection};");
-                ArrayValue.Emit(irProgram, primaryEmitter, typeargs, (arrayPromise) =>
-                {
-                    primaryEmitter.Append($"arr{indirection} = ");
-                    arrayPromise(primaryEmitter);
-                    primaryEmitter.AppendLine(';');
-                }, Emitter.NullPromise, true);
+                primaryEmitter.SetArgument(ArrayValue, $"arr{indirection}", irProgram, typeargs, true);
 
                 if (Operation != ArrayOperation.GetArrayLength && ArrayValue.RequiresDisposal(irProgram, typeargs, true))
                     throw new CannotEmitDestructorError(ArrayValue);
@@ -162,9 +157,6 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     else if (Operation == ArrayOperation.GetArrayHandle)
                         emitter.Append(".buffer");
                 });
-
-                if (ArrayValue.RequiresDisposal(irProgram, typeargs, true))
-                    ArrayValue.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"arr{indirection}"), Emitter.NullPromise);
 
                 primaryEmitter.AppendEndBlock();
             }

--- a/NoHoPython/Compilation/Values/InterpolatedString.cs
+++ b/NoHoPython/Compilation/Values/InterpolatedString.cs
@@ -249,12 +249,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (InterpolatedValues[i] is IRValue irValue)
                 {
                     primaryEmitter.AppendLine($"{irValue.Type.SubstituteWithTypearg(typeargs).GetCName(irProgram)} arg{i}{indirection};");
-                    irValue.Emit(irProgram, primaryEmitter, typeargs, (valuePromise) =>
-                    {
-                        primaryEmitter.Append($"arg{i}{indirection} = ");
-                        valuePromise(primaryEmitter);
-                        primaryEmitter.AppendLine(';');
-                    }, Emitter.NullPromise, true);
+                    primaryEmitter.SetArgument(irValue, $"arg{i}{indirection}", irProgram, typeargs, true);
                 }
 
             primaryEmitter.Append($"int count{indirection} = snprintf(NULL, 0, {format}");
@@ -266,10 +261,6 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 destination((emitter) => emitter.Append($"({Type.GetCName(irProgram)}){{.buffer = cstr{indirection}, .length=count{indirection}}}"));
             else
                 destination((emitter) => emitter.Append($"cstr{indirection}"));
-
-            for (int i = 0; i < InterpolatedValues.Count; i++)
-                if (InterpolatedValues[i] is IRValue irValue && irValue.RequiresDisposal(irProgram, typeargs, true))
-                    irValue.Type.SubstituteWithTypearg(typeargs).EmitFreeValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"arg{i}{indirection}"), Emitter.NullPromise);
             primaryEmitter.AppendEndBlock();
         }
     }

--- a/NoHoPython/Compilation/Values/InterpolatedString.cs
+++ b/NoHoPython/Compilation/Values/InterpolatedString.cs
@@ -236,8 +236,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
             void EmitFormatArgs()
             {
                 for (int i = 0; i < InterpolatedValues.Count; i++)
-                    if (InterpolatedValues[i] is IRValue)
-                        primaryEmitter.Append($", arg{i}{indirection}");
+                    if (InterpolatedValues[i] is IRValue value)
+                    {
+                        primaryEmitter.Append(", ");
+                        int j = i;
+                        value.Type.SubstituteWithTypearg(typeargs).EmitFormatValue(irProgram, primaryEmitter, (emitter) => emitter.Append($"arg{j}{indirection}"));
+                    }
                 primaryEmitter.AppendLine(");");
             }
 
@@ -255,7 +259,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
             primaryEmitter.Append($"int count{indirection} = snprintf(NULL, 0, {format}");
             EmitFormatArgs();
-            primaryEmitter.AppendLine($"char* cstr{indirection} = {irProgram.MemoryAnalyzer.Allocate($"count{indirection} + 1")};");
+            primaryEmitter.AppendLine($"char* cstr{indirection} = malloc(count{indirection} + 1);");
             primaryEmitter.Append($"snprintf(cstr{indirection}, count{indirection} + 1, {format}");
             EmitFormatArgs();
             if (TargetArrayChar)

--- a/NoHoPython/Compilation/Values/Literals.cs
+++ b/NoHoPython/Compilation/Values/Literals.cs
@@ -6,27 +6,30 @@ namespace NoHoPython.IntermediateRepresentation.Values
 {
     partial class IntegerLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) => emitter.Append(Number.ToString());
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) => emitter.Append(Number.ToString()));
     }
 
     partial class DecimalLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) => emitter.Append(Number.ToString());
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) => emitter.Append(Number.ToString()));
     }
 
     partial class CharacterLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
-        public static void EmitCChar(IEmitter emitter, char c, bool formatChar)
+        public static void EmitCChar(Emitter emitter, char c, bool formatChar)
         {
             switch (c)
             {
@@ -70,7 +73,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
         }
 
-        public static void EmitCString(IEmitter emitter, string str, bool formatStr, bool quoteEncapsulate)
+        public static void EmitCString(Emitter emitter, string str, bool formatStr, bool quoteEncapsulate)
         {
             if(quoteEncapsulate)
                 emitter.Append('\"');
@@ -84,60 +87,66 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) =>
         {
             emitter.Append('\'');
             EmitCChar(emitter, Character, false);
             emitter.Append('\'');
-        }
+        });
     }
 
     partial class TrueLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) => emitter.Append('1');
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) => emitter.Append('1'));
     }
 
     partial class FalseLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) => emitter.Append('0');
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) => emitter.Append('0'));
     }
 
     partial class NullPointerLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
         
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) => emitter.Append("NULL");
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) => emitter.Append("NULL"));
     }
 
     partial class StaticCStringLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) =>
         {
             emitter.Append('\"');
             foreach (char c in String)
                 CharacterLiteral.EmitCChar(emitter, c, false);
             emitter.Append('\"');
-        }
+        });
     }
 
     partial class EmptyTypeLiteral
     {
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
 
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) { }
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval) { }
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) { }
     }
 
     partial class ArrayLiteral
@@ -148,39 +157,60 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Elements.ForEach((element) => element.ScopeForUsedTypes(typeargs, irBuilder));
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => !(isTemporaryEval && Elements.All((elem) => !elem.RequiresDisposal(typeargs, true)));
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => !(isTemporaryEval && !Elements.Any((elem) => elem.RequiresDisposal(irProgram, typeargs, true)) && !Elements.Any((elem) => elem.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval)) && IRValue.EvaluationOrderGuarenteed(Elements));
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => RequiresDisposal(irProgram, typeargs, isTemporaryEval);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            void EmitStatic()
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
-                emitter.Append($"({ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)}[])");
-                emitter.Append('{');
+                int indirection = primaryEmitter.AppendStartBlock();
 
+                primaryEmitter.AppendLine($"{ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)}* res{indirection} = {irProgram.MemoryAnalyzer.Allocate(Elements.Count.ToString())};");
                 for (int i = 0; i < Elements.Count; i++)
                 {
-                    if (i > 0)
-                        emitter.Append(", ");
-                    Elements[i].Emit(irProgram, emitter, typeargs, responsibleDestroyer, isTemporaryEval);
+                    Elements[i].Emit(irProgram, primaryEmitter, typeargs, (elemPromise) =>
+                    {
+                        primaryEmitter.Append($"res[{i}] = ");
+
+                        if (Elements[i].RequiresDisposal(irProgram, typeargs, isTemporaryEval) || !RequiresDisposal(irProgram, typeargs, isTemporaryEval))
+                            elemPromise(primaryEmitter);
+                        else
+                            ElementType.EmitCopyValue(irProgram, primaryEmitter, elemPromise, responsibleDestroyer);
+
+                        primaryEmitter.AppendLine(';');
+                    }, responsibleDestroyer, isTemporaryEval);
+                    primaryEmitter.AppendLine();
                 }
-                emitter.Append('}');
+
+                destination((emitter) => primaryEmitter.Append($"res{indirection}"));
+                primaryEmitter.AppendEndBlock();
             }
-
-            if(!RequiresDisposal(typeargs, isTemporaryEval))
-            {
-                EmitStatic();
-                return;
-            }
-
-            string sizeCSource = $"{Elements.Count} * sizeof({ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)})";
-            emitter.Append($"memcpy({irProgram.MemoryAnalyzer.Allocate(sizeCSource)}, ");
-
-            if (Elements.Count == 0)
-                emitter.Append("NULL");
             else
-                EmitStatic();
+                destination((emitter) =>
+                {
+                    if (Elements.All((elem) => elem is CharacterLiteral))
+                    {
+                        emitter.Append('\"');
+                        Elements.ForEach((elem) => CharacterLiteral.EmitCChar(emitter, ((CharacterLiteral)elem).Character, false));
+                        emitter.Append('\"');
+                    }
+                    else
+                    {
+                        emitter.Append($"({ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)}[])");
+                        emitter.Append('{');
 
-            emitter.Append($", {sizeCSource})");
+                        for (int i = 0; i < Elements.Count; i++)
+                        {
+                            if (i > 0)
+                                emitter.Append(", ");
+
+                            IRValue.EmitDirect(irProgram, emitter, Elements[i], typeargs, responsibleDestroyer, true);
+                        }
+                        emitter.Append('}');
+                    }
+                });
         }
     }
 
@@ -189,41 +219,67 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public void ScopeForUsedTypes(Dictionary<TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder)
         {
             Type.SubstituteWithTypearg(typeargs).ScopeForUsedTypes(irBuilder);
-            TupleElements.ForEach((element) => element.ScopeForUsedTypes(typeargs, irBuilder));
+            Elements.ForEach((element) => element.ScopeForUsedTypes(typeargs, irBuilder));
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval)
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => !Elements.Any(element => element.RequiresDisposal(irProgram, typeargs, isTemporaryEval)) || Elements.Any((elem) => elem.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval)) || !IRValue.EvaluationOrderGuarenteed(Elements);
+
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => RequiresDisposal(irProgram, typeargs, isTemporaryEval);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            foreach (IType valueType in TupleType.ValueTypes.Keys)
-                if (valueType.SubstituteWithTypearg(typeargs).RequiresDisposal)
-                    return true;
-            return false;
-        }
-
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
-        {
-            if (!IRValue.EvaluationOrderGuarenteed(TupleElements))
-                throw new CannotEnsureOrderOfEvaluation(this);
-
-            emitter.Append($"({TupleType.SubstituteWithTypearg(typeargs).GetCName(irProgram)}) {{");
-
             List<Property> initializeProperties = ((TupleType)TupleType.SubstituteWithTypearg(typeargs)).GetProperties();
             ITypeComparer typeComparer = new ITypeComparer();
             initializeProperties.Sort((a, b) => typeComparer.Compare(a.Type, b.Type));
-            
-            for(int i = 0; i < initializeProperties.Count; i++)
+            Elements.Sort((a, b) => typeComparer.Compare(a.Type, b.Type));
+
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
             {
-                if (i > 0)
-                    emitter.Append(", ");
+                int indirection = primaryEmitter.AppendStartBlock();
 
-                emitter.Append($".{initializeProperties[i].Name} = ");
-                if (TupleElements[i].RequiresDisposal(typeargs, false))
-                    TupleElements[i].Emit(irProgram, emitter, typeargs, responsibleDestroyer, false);
-                else
-                    initializeProperties[i].Type.EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(TupleElements[i], irProgram, typeargs, "NULL"), responsibleDestroyer);
+                primaryEmitter.AppendLine($"{TupleType.SubstituteWithTypearg(typeargs).GetCName(irProgram)} res{indirection};");
+                for (int i = 0; i < initializeProperties.Count; i++)
+                    Elements[i].Emit(irProgram, primaryEmitter, typeargs, (elemPromise) =>
+                    {
+                        primaryEmitter.Append($".{initializeProperties[i].Name} = ");
+
+                        if (Elements[i].RequiresDisposal(irProgram, typeargs, isTemporaryEval) || isTemporaryEval)
+                            elemPromise(primaryEmitter);
+                        else
+                            initializeProperties[i].Type.EmitCopyValue(irProgram, primaryEmitter, elemPromise, responsibleDestroyer);
+
+                        primaryEmitter.AppendLine(';');
+                    }, responsibleDestroyer, isTemporaryEval);
+
+                destination((emitter) => primaryEmitter.Append($"res{indirection}"));
+                primaryEmitter.AppendEndBlock();
             }
+            else
+                destination((emitter) =>
+                {
+                    emitter.Append($"({TupleType.SubstituteWithTypearg(typeargs).GetCName(irProgram)}) {{");
+            
+                    for(int i = 0; i < initializeProperties.Count; i++)
+                    {
+                        if (i > 0)
+                            emitter.Append(", ");
 
-            emitter.Append('}');
+                        emitter.Append($".{initializeProperties[i].Name} = ");
+
+                        Debug.Assert(!Elements[i].MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval));
+                        if (isTemporaryEval)
+                            IRValue.EmitDirect(irProgram, emitter, Elements[i], typeargs, Emitter.NullPromise, true);
+                        else
+                        {
+                            if (Elements[i].RequiresDisposal(irProgram, typeargs, false))
+                                IRValue.EmitDirect(irProgram, emitter, Elements[i], typeargs, responsibleDestroyer, false);
+                            else
+                                initializeProperties[i].Type.EmitCopyValue(irProgram, emitter, IRValue.EmitDirectPromise(irProgram, Elements[i], typeargs, responsibleDestroyer, false), responsibleDestroyer);
+                        }
+                    }
+
+                    emitter.Append('}');
+                });
         }
     }
 
@@ -236,26 +292,67 @@ namespace NoHoPython.IntermediateRepresentation.Values
             ProtoValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => Length.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval) || ProtoValue.MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval) || !IRValue.EvaluationOrderGuarenteed(Length, ProtoValue);
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval)
         {
-            if (!IRValue.EvaluationOrderGuarenteed(Length, ProtoValue))
-                throw new CannotEnsureOrderOfEvaluation(this);
-            
-            emitter.Append($"marshal_proto{Type.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(");
-            Length.Emit(irProgram, emitter, typeargs, "NULL", true);
-            emitter.Append(", ");
+            if (MustUseDestinationPromise(irProgram, typeargs, isTemporaryEval))
+            {
+                int indirection = primaryEmitter.AppendStartBlock();
+                primaryEmitter.AppendLine($"long length{indirection}; {ElementType.SubstituteWithTypearg(typeargs).GetCName(irProgram)} proto_val{indirection}");
+                Length.Emit(irProgram, primaryEmitter, typeargs, (lengthPromise) =>
+                {
+                    primaryEmitter.Append($"length{indirection} = ");
+                    lengthPromise(primaryEmitter);
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                ProtoValue.Emit(irProgram, primaryEmitter, typeargs, (protoPromise) =>
+                {
+                    primaryEmitter.Append($"proto_val{indirection} = ");
 
-            if (ProtoValue.RequiresDisposal(typeargs, false))
-                ProtoValue.Emit(irProgram, emitter, typeargs, "NULL", false);
-            else
-                ElementType.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(ProtoValue, irProgram, typeargs, "NULL"), "NULL");
+                    if (ProtoValue.RequiresDisposal(irProgram, typeargs, true))
+                        protoPromise(primaryEmitter);
+                    else
+                        ElementType.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, primaryEmitter, protoPromise, Emitter.NullPromise);
 
-            if (Type.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
-                emitter.Append($", {responsibleDestroyer})");
+                    primaryEmitter.AppendLine(';');
+                }, Emitter.NullPromise, true);
+                destination((emitter) =>
+                {
+                    emitter.Append($"marshal_proto{Type.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(len{indirection}, proto_val{indirection}");
+
+                    if (ElementType.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
+                    {
+                        primaryEmitter.Append(", ");
+                        responsibleDestroyer(primaryEmitter);
+                    }
+                    primaryEmitter.Append(')');
+                });
+                primaryEmitter.AppendEndBlock();
+            }
             else
-                emitter.Append(')');
+                destination((emitter) =>
+                {
+                    emitter.Append($"marshal_proto{Type.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(");
+                    IRValue.EmitDirect(irProgram, emitter, Length, typeargs, Emitter.NullPromise, true);
+                    emitter.Append(", ");
+                    ProtoValue.Emit(irProgram, primaryEmitter, typeargs, (protoValPromise) =>
+                    {
+                        if (ProtoValue.RequiresDisposal(irProgram, typeargs, true))
+                            protoValPromise(primaryEmitter);
+                        else
+                            ElementType.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, primaryEmitter, protoValPromise, Emitter.NullPromise);
+                    }, Emitter.NullPromise, true);
+
+                    if (ElementType.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
+                    {
+                        primaryEmitter.Append(", ");
+                        responsibleDestroyer(primaryEmitter);
+                    }
+                    primaryEmitter.Append(')');
+                });
         }
     }
 
@@ -267,23 +364,31 @@ namespace NoHoPython.IntermediateRepresentation.Values
             ProtoValue.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public bool RequiresDisposal(Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
+        public bool RequiresDisposal(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => true;
 
-        public void Emit(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, string responsibleDestroyer, bool isTemporaryEval)
+        public bool MustUseDestinationPromise(IRProgram irProgram, Dictionary<TypeParameter, IType> typeargs, bool isTemporaryEval) => false;
+
+        public void Emit(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, Emitter.SetPromise destination, Emitter.Promise responsibleDestroyer, bool isTemporaryEval) => destination((emitter) =>
         {
             emitter.Append($"buffer_alloc_{ElementType.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}(");
-            
-            if (ProtoValue.RequiresDisposal(typeargs, false))
-                ProtoValue.Emit(irProgram, emitter, typeargs, "NULL", false);
-            else
-                ElementType.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, BufferedEmitter.EmitBufferedValue(ProtoValue, irProgram, typeargs, "NULL"), "NULL");
+
+            ProtoValue.Emit(irProgram, emitter, typeargs, (protoValPromise) =>
+            {
+                if (ProtoValue.RequiresDisposal(irProgram, typeargs, true))
+                    protoValPromise(emitter);
+                else
+                    ElementType.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, protoValPromise, Emitter.NullPromise);
+            }, Emitter.NullPromise, true);
+
             emitter.Append($", {Length}");
 
-            if (Type.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
-                emitter.Append($", {responsibleDestroyer})");
-            else
-                emitter.Append(')');
-        }
+            if (ElementType.SubstituteWithTypearg(typeargs).MustSetResponsibleDestroyer)
+            {
+                primaryEmitter.Append(", ");
+                responsibleDestroyer(primaryEmitter);
+            }
+            primaryEmitter.Append(')');
+        });
     }
 
     partial class AllocRecord
@@ -294,14 +399,17 @@ namespace NoHoPython.IntermediateRepresentation.Values
             base.ScopeForUsedTypes(typeargs, irBuilder);
         }
 
-        public override void EmitCall(IRProgram irProgram, IEmitter emitter, Dictionary<TypeParameter, IType> typeargs, SortedSet<int> releasedArguments, int currentNestedCall, string responsibleDestroyer)
+        public override void EmitCall(IRProgram irProgram, Emitter primaryEmitter, Dictionary<TypeParameter, IType> typeargs, List<Emitter.Promise> argPromises, Emitter.Promise responsibleDestroyer)
         {
             RecordType recordType = (RecordType)RecordPrototype.SubstituteWithTypearg(typeargs);
-            emitter.Append($"construct_{recordType.GetOriginalStandardIdentifer(irProgram)}(");
-            EmitArguments(irProgram, emitter, typeargs, releasedArguments, currentNestedCall);
+            primaryEmitter.Append($"construct_{recordType.GetOriginalStandardIdentifer(irProgram)}(");
+            EmitArguments(primaryEmitter, argPromises);
+
             if (Arguments.Count > 0)
-                emitter.Append(", ");
-            emitter.Append($"(nhp_std_record_mask_t*){responsibleDestroyer})");
+                primaryEmitter.Append(", ");
+            primaryEmitter.Append($"({RecordType.StandardRecordMask})");
+            responsibleDestroyer(primaryEmitter);
+            primaryEmitter.Append(')');
         }
     }
 }

--- a/NoHoPython/Compilation/Values/Operators.cs
+++ b/NoHoPython/Compilation/Values/Operators.cs
@@ -451,7 +451,11 @@ namespace NoHoPython.IntermediateRepresentation.Values
                     emitter.Append('(');
                     IRValue.EmitDirect(irProgram, emitter, Record, typeargs, Emitter.NullPromise, isTemporaryEval);
                     emitter.Append($"->{Property.Name} = ");
-                    IRValue.EmitDirect(irProgram, emitter, Value, typeargs, IRValue.EmitDirectPromise(irProgram, Record.GetPostEvalPure(), typeargs, Emitter.NullPromise, true), false);
+                    Emitter.Promise record = IRValue.EmitDirectPromise(irProgram, Record.GetPostEvalPure(), typeargs, Emitter.NullPromise, true);
+                    if (Value.RequiresDisposal(irProgram, typeargs, false))
+                        IRValue.EmitDirect(irProgram, emitter, Value, typeargs, record, false);
+                    else
+                        Value.Type.SubstituteWithTypearg(typeargs).EmitCopyValue(irProgram, emitter, IRValue.EmitDirectPromise(irProgram, Value, typeargs, record, false), record);
                     emitter.Append(')');
                 });
         }

--- a/NoHoPython/IntermediateRepresentation/Analysis/CompileTimeResponsibleDestroyer.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/CompileTimeResponsibleDestroyer.cs
@@ -122,7 +122,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class UnwrapEnumValue
     {
-        public IRValue? GetResponsibleDestroyer() => null;
+        public IRValue? GetResponsibleDestroyer() => EnumValue.GetResponsibleDestroyer();
     }
 
     partial class CheckEnumOption

--- a/NoHoPython/IntermediateRepresentation/Analysis/CompileTimeResponsibleDestroyer.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/CompileTimeResponsibleDestroyer.cs
@@ -151,7 +151,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 if (ifTrueResponsibleDestroyer == null && ifFalseResponsibleDestroyer == null)
                     return null;
 
-                return new IfElseValue(Condition.GetPostEvalPure(), ifTrueResponsibleDestroyer ?? new NullPointerLiteral(Primitive.Handle, ErrorReportedElement), ifFalseResponsibleDestroyer ?? new NullPointerLiteral(Primitive.Handle, ErrorReportedElement), ErrorReportedElement);
+                return new IfElseValue(Type, Condition.GetPostEvalPure(), ifTrueResponsibleDestroyer ?? new NullPointerLiteral(Primitive.Handle, ErrorReportedElement), ifFalseResponsibleDestroyer ?? new NullPointerLiteral(Primitive.Handle, ErrorReportedElement), ErrorReportedElement);
             }
         }
     }

--- a/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
@@ -180,7 +180,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class ArithmeticOperator
     {
-        public override IRValue GetPostEvalPure() => new ArithmeticOperator(Operation, Left.GetPostEvalPure(), Right.GetPostEvalPure(), ErrorReportedElement);
+        public override IRValue GetPostEvalPure() => new ArithmeticOperator(Type, Operation, Left.GetPostEvalPure(), Right.GetPostEvalPure(), ErrorReportedElement);
     }
 
     partial class PointerAddOperator
@@ -193,7 +193,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public bool IsPure => Array.IsPure && Index.IsPure;
         public bool IsConstant => Array.IsConstant && Index.IsConstant;
 
-        public IRValue GetPostEvalPure() => new GetValueAtIndex(Array.GetPostEvalPure(), Index.GetPostEvalPure(), ErrorReportedElement);
+        public IRValue GetPostEvalPure() => new GetValueAtIndex(Type, Array.GetPostEvalPure(), Index.GetPostEvalPure(), ErrorReportedElement);
     }
 
     partial class SetValueAtIndex
@@ -201,7 +201,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public bool IsPure => false;
         public bool IsConstant => Array.IsConstant && Index.IsConstant && Value.IsConstant;
 
-        public IRValue GetPostEvalPure() => GetValueAtIndex.ComposeGetValueAtIndex(Array.GetPostEvalPure(), Index.GetPostEvalPure(), Type, ErrorReportedElement);
+        public IRValue GetPostEvalPure() => new GetValueAtIndex(Type, Array.GetPostEvalPure(), Index.GetPostEvalPure(), ErrorReportedElement);
     }
 
     partial class GetPropertyValue
@@ -289,7 +289,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public bool IsPure => Condition.IsPure && IfTrueValue.IsPure && IfFalseValue.IsPure;
         public bool IsConstant => Condition.IsConstant && IfTrueValue.IsConstant && IfFalseValue.IsConstant;
 
-        public IRValue GetPostEvalPure() => new IfElseValue(Condition.GetPostEvalPure(), IfTrueValue.GetPostEvalPure(), IfFalseValue.GetPostEvalPure(), ErrorReportedElement);
+        public IRValue GetPostEvalPure() => new IfElseValue(Type, Condition.GetPostEvalPure(), IfTrueValue.GetPostEvalPure(), IfFalseValue.GetPostEvalPure(), ErrorReportedElement);
     }
 
     partial class SizeofOperator

--- a/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
@@ -11,6 +11,19 @@
         public static bool EvaluationOrderGuarenteed(params IRValue[] operands) => EvaluationOrderGuarenteed(operands as IEnumerable<IRValue>); 
 
         public static bool EvaluationOrderGuarenteed(IEnumerable<IRValue> operands) => operands.All((operand) => operand.IsPure) || operands.All((operand) => operand.IsConstant);
+
+        public static bool HasPostEvalPure(IRValue value)
+        {
+            try
+            {
+                value.GetPostEvalPure();
+                return true;
+            }
+            catch (NoPostEvalPureValue)
+            {
+                return false;
+            }
+        }
     }
 }
 
@@ -90,10 +103,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class TupleLiteral
     {
-        public bool IsPure => TupleElements.TrueForAll((elem) => elem.IsPure);
-        public bool IsConstant => TupleElements.TrueForAll((elem) => elem.IsConstant);
+        public bool IsPure => Elements.TrueForAll((elem) => elem.IsPure);
+        public bool IsConstant => Elements.TrueForAll((elem) => elem.IsConstant);
 
-        public IRValue GetPostEvalPure() => new TupleLiteral(TupleElements.Select((element) => element.GetPostEvalPure()).ToList(), ErrorReportedElement);
+        public IRValue GetPostEvalPure() => new TupleLiteral(Elements.Select((element) => element.GetPostEvalPure()).ToList(), ErrorReportedElement);
     }
 
     partial class MarshalIntoLowerTuple

--- a/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/EffectAnalysis.cs
@@ -326,10 +326,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class UnwrapEnumValue
     {
-        public bool IsPure => EnumValue.IsPure;
+        public bool IsPure => false;
         public bool IsConstant => EnumValue.IsConstant;
 
-        public IRValue GetPostEvalPure() => new UnwrapEnumValue(EnumValue.GetPostEvalPure(), Type, ErrorReportedElement);
+        public IRValue GetPostEvalPure() => new UnwrapEnumValue(EnumValue.GetPostEvalPure(), Type, ErrorReturnEnum, ErrorReportedElement);
     }
 
     partial class CheckEnumOption

--- a/NoHoPython/IntermediateRepresentation/Analysis/InitializationAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/InitializationAnalysis.cs
@@ -224,9 +224,9 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class TupleLiteral
     {
-        public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration, bool isUsingValue) => TupleElements.ForEach((element) => element.AnalyzePropertyInitialization(initializedProperties, recordDeclaration, true));
+        public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration, bool isUsingValue) => Elements.ForEach((element) => element.AnalyzePropertyInitialization(initializedProperties, recordDeclaration, true));
 
-        public void NonConstructorPropertyAnalysis() => TupleElements.ForEach((element) => element.NonConstructorPropertyAnalysis());
+        public void NonConstructorPropertyAnalysis() => Elements.ForEach((element) => element.NonConstructorPropertyAnalysis());
     }
 
     partial class MarshalIntoLowerTuple

--- a/NoHoPython/IntermediateRepresentation/Analysis/InitializationAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/InitializationAnalysis.cs
@@ -5,6 +5,7 @@ namespace NoHoPython.IntermediateRepresentation
 {
     partial interface IRValue
     {
+        //is using value indicates whether the entirety of a value is being evaluated, or only a known initialized property or index is being evaluated
         public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration, bool isUsingValue);
         public void NonConstructorPropertyAnalysis();
     }
@@ -476,6 +477,8 @@ namespace NoHoPython.IntermediateRepresentation.Values
     partial class UnwrapEnumValue
     {
         public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration, bool isUsingValue) => EnumValue.AnalyzePropertyInitialization(initializedProperties, recordDeclaration, true);
+
+        public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => AnalyzePropertyInitialization(initializedProperties, recordDeclaration, true);
 
         public void NonConstructorPropertyAnalysis() => EnumValue.NonConstructorPropertyAnalysis();
     }

--- a/NoHoPython/IntermediateRepresentation/Analysis/RefinementAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/RefinementAnalysis.cs
@@ -13,7 +13,7 @@ namespace NoHoPython.IntermediateRepresentation
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement);
 
         //when a variable is set to ths value, this function will make the correct variable refinements 
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry);
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry);
 
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder);
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder);
@@ -26,7 +26,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -35,7 +35,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -44,7 +44,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -53,7 +53,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -62,7 +62,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -71,7 +71,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -80,7 +80,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -89,7 +89,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -98,7 +98,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -107,7 +107,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -116,7 +116,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -125,7 +125,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -134,7 +134,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -143,7 +143,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -152,7 +152,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -161,7 +161,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public virtual void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -182,7 +182,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -191,7 +191,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -199,7 +199,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     partial class GetPropertyValue
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
 
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement)
         {
@@ -218,7 +218,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
 
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null; //refinement entry should be cleared immediatley upon IR generation
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
@@ -228,7 +228,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -237,7 +237,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -246,7 +246,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -264,7 +264,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 entry.Refinement = assumedRefinement;
         }
 
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
 
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => irBuilder.SymbolMarshaller.CurrentCodeBlock.GetRefinementEntry(Variable, true);
 
@@ -284,7 +284,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -293,7 +293,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -302,7 +302,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -311,7 +311,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -320,7 +320,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -329,7 +329,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -338,7 +338,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -347,7 +347,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -359,14 +359,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
 
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) => destinationEntry.Refinement = (Value.Type, EnumDeclaration.GetRefinedEnumEmitter(TargetType, Value.Type));
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) => destinationEntry.Refinement = (Value.Type, EnumDeclaration.GetRefinedEnumEmitter(TargetType, Value.Type));
     }
 
     partial class UnwrapEnumValue
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -376,7 +376,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) => EnumValue.RefineAssumeType(irBuilder, (Option, EnumDeclaration.GetRefinedEnumEmitter((EnumType)EnumValue.Type, Option)));
 
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -385,7 +385,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }
@@ -394,7 +394,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public void RefineIfTrue(AstIRProgramBuilder irBuilder) { }
         public void RefineAssumeType(AstIRProgramBuilder irBuilder, (IType, CodeBlock.RefinementEmitter?) assumedRefinement) { }
-        public void RefineSetVariable(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
+        public void RefineSet(AstIRProgramBuilder irBuilder, CodeBlock.RefinementEntry destinationEntry) { }
         public CodeBlock.RefinementEntry? GetRefinementEntry(AstIRProgramBuilder irBuilder) => null;
         public CodeBlock.RefinementEntry? CreateRefinementEntry(AstIRProgramBuilder irBuilder) => null;
     }

--- a/NoHoPython/IntermediateRepresentation/Analysis/ReturnAnalysis.cs
+++ b/NoHoPython/IntermediateRepresentation/Analysis/ReturnAnalysis.cs
@@ -88,13 +88,20 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
     partial class IfBlock
     {
-        public bool AllCodePathsReturn() => false;
+        public bool AllCodePathsReturn() => Condition.IsTruey && IfTrueBlock.CodeBlockAllCodePathsReturn();
         public bool SomeCodePathsBreak() => IfTrueBlock.CodeBlockSomeCodePathsBreak();
     }
 
     partial class IfElseBlock
     {
-        public bool AllCodePathsReturn() => IfTrueBlock.CodeBlockAllCodePathsReturn() && IfFalseBlock.CodeBlockAllCodePathsReturn();
+        public bool AllCodePathsReturn()
+        {
+            if (Condition.IsTruey)
+                return IfTrueBlock.CodeBlockAllCodePathsReturn();
+            else if (Condition.IsFalsey)
+                return IfFalseBlock.CodeBlockAllCodePathsReturn();
+            return IfTrueBlock.CodeBlockAllCodePathsReturn() && IfFalseBlock.CodeBlockAllCodePathsReturn();
+        }
         public bool SomeCodePathsBreak() => IfTrueBlock.CodeBlockSomeCodePathsBreak() || IfFalseBlock.CodeBlockSomeCodePathsBreak();
     }
 
@@ -175,6 +182,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
     }
 
     partial class SetVariable
+    {
+        public bool AllCodePathsReturn() => false;
+        public bool SomeCodePathsBreak() => false;
+    }
+
+    partial class UnwrapEnumValue
     {
         public bool AllCodePathsReturn() => false;
         public bool SomeCodePathsBreak() => false;

--- a/NoHoPython/IntermediateRepresentation/LowLevel.cs
+++ b/NoHoPython/IntermediateRepresentation/LowLevel.cs
@@ -28,7 +28,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public override IType Type { get; }
 
-        public MemoryGet(IType type, IRValue address, IRValue index, IAstElement errorReportedElement) : base(address, ArithmeticCast.CastTo(index, Primitive.Integer), false, errorReportedElement)
+        public MemoryGet(IType type, IRValue address, IRValue index, IAstElement errorReportedElement) : base(address, ArithmeticCast.CastTo(index, Primitive.Integer), errorReportedElement)
         {
             Type = type;
 

--- a/NoHoPython/IntermediateRepresentation/RefinementLinking.cs
+++ b/NoHoPython/IntermediateRepresentation/RefinementLinking.cs
@@ -5,7 +5,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 {
     partial class CodeBlock
     {
-        public delegate void RefinementEmitter(IRProgram irProgram, IEmitter emitter, string variableIdentifier, Dictionary<TypeParameter, IType> typeargs);
+        public delegate void RefinementEmitter(IRProgram irProgram, Emitter emitter, Emitter.Promise value, Dictionary<TypeParameter, IType> typeargs);
 
         public sealed class RefinementEntry
         {

--- a/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
@@ -98,10 +98,10 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 return ((CodeBlock)parentContainer).GetLoopBreakLabelId(errorReportedElement, irBuilder);
         }
 
-        public override IScopeSymbol? FindSymbol(string identifier, IAstElement errorReportedElement)
+        public override IScopeSymbol? FindSymbol(string identifier)
         {
-            IScopeSymbol? result = base.FindSymbol(identifier, errorReportedElement);
-            return result ?? (parentContainer?.FindSymbol(identifier, errorReportedElement));
+            IScopeSymbol? result = base.FindSymbol(identifier);
+            return result ?? (parentContainer?.FindSymbol(identifier));
         }
     }
 }

--- a/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/CodeBlock.cs
@@ -54,33 +54,35 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             Statements = statements;
         }
 
-        public List<Variable> GetCurrentLocals(ProcedureDeclaration currentProcedure)
-        {
-            if (parentContainer == null || parentContainer is not CodeBlock || this == currentProcedure)
-                return new(LocalVariables);
-            else
-            {
-                List<Variable> combined = new();
-                combined.AddRange(((CodeBlock)parentContainer).GetCurrentLocals(currentProcedure));
-                combined.AddRange(LocalVariables);
-                return combined;
-            }
-        }
+        //depreceated beacuse of emitter destructor stack
+        //public List<Variable> GetCurrentLocals(ProcedureDeclaration currentProcedure)
+        //{
+        //    if (parentContainer == null || parentContainer is not CodeBlock || this == currentProcedure)
+        //        return new(LocalVariables);
+        //    else
+        //    {
+        //        List<Variable> combined = new();
+        //        combined.AddRange(((CodeBlock)parentContainer).GetCurrentLocals(currentProcedure));
+        //        combined.AddRange(LocalVariables);
+        //        return combined;
+        //    }
+        //}
 
-        public List<Variable> GetLoopLocals(IAstElement errorReportedElement)
-        {
-            if (this.IsLoop)
-                return new(LocalVariables);
-            if (parentContainer == null || parentContainer is not CodeBlock)
-                throw new UnexpectedLoopStatementException(errorReportedElement);
-            else
-            {
-                List<Variable> combined = new();
-                combined.AddRange(((CodeBlock)parentContainer).GetLoopLocals(errorReportedElement));
-                combined.AddRange(LocalVariables);
-                return combined;
-            }
-        }
+        //depreceated beacuse of emitter destructor stack
+        //public List<Variable> GetLoopLocals(IAstElement errorReportedElement)
+        //{
+        //    if (this.IsLoop)
+        //        return new(LocalVariables);
+        //    if (parentContainer == null || parentContainer is not CodeBlock)
+        //        throw new UnexpectedLoopStatementException(errorReportedElement);
+        //    else
+        //    {
+        //        List<Variable> combined = new();
+        //        combined.AddRange(((CodeBlock)parentContainer).GetLoopLocals(errorReportedElement));
+        //        combined.AddRange(LocalVariables);
+        //        return combined;
+        //    }
+        //}
 
         public int GetLoopBreakLabelId(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder)
         {

--- a/NoHoPython/IntermediateRepresentation/Statements/Conditional.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Conditional.cs
@@ -127,14 +127,12 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         public IAstElement ErrorReportedElement { get; private set; }
         public Token Action { get; private set; }
 
-        private List<Variable> activeLoopVariables;
         private int? breakLabelId;
 
         public LoopStatement(Token action, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
         {
             ErrorReportedElement = errorReportedElement;
             Action = action;
-            activeLoopVariables = irBuilder.SymbolMarshaller.CurrentCodeBlock.GetLoopLocals(errorReportedElement);
 
             breakLabelId = action.Type == TokenType.Break ? irBuilder.SymbolMarshaller.CurrentCodeBlock.GetLoopBreakLabelId(errorReportedElement, irBuilder) : null;
         }

--- a/NoHoPython/IntermediateRepresentation/Statements/EnumDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/EnumDeclaration.cs
@@ -11,9 +11,13 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         public static CodeBlock.RefinementEmitter GetRefinedEnumEmitter(EnumType enumType, IType type)
         {
             if (type.IsEmpty)
-                return (IRProgram irProgram, IEmitter emitter, string variableIdentifier, Dictionary<TypeParameter, IType> typeargs) => emitter.Append(enumType.GetCEnumOptionForType(irProgram, type));
+                return (IRProgram irProgram, Emitter emitter, Emitter.Promise value, Dictionary<TypeParameter, IType> typeargs) => emitter.Append(enumType.GetCEnumOptionForType(irProgram, type));
 
-            return (IRProgram irProgram, IEmitter emitter, string variableIdentifier, Dictionary<TypeParameter, IType> typeargs) => emitter.Append($"{variableIdentifier}.data.{type.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}_set");
+            return (IRProgram irProgram, Emitter emitter, Emitter.Promise value, Dictionary<TypeParameter, IType> typeargs) =>
+            {
+                value(emitter);
+                emitter.Append($".data.{type.SubstituteWithTypearg(typeargs).GetStandardIdentifier(irProgram)}_set");
+            };
         }
 
         public Syntax.IAstElement ErrorReportedElement { get; private set; }

--- a/NoHoPython/IntermediateRepresentation/Statements/EnumDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/EnumDeclaration.cs
@@ -230,6 +230,7 @@ namespace NoHoPython.Typing
 
         public string TypeName => Name;
         public string Identifier => IScopeSymbol.GetAbsolouteName(this);
+        public string PrototypeIdentifier => Identifier;
         public bool IsEmpty => true;
 
         public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement, Syntax.AstIRProgramBuilder irBuilder) => new EmptyTypeLiteral(this, errorReportedElement);
@@ -272,7 +273,8 @@ namespace NoHoPython.Typing
 
         public bool IsNativeCType => false;
         public string TypeName => $"{EnumDeclaration.Name}{(TypeArguments.Count == 0 ? string.Empty : $"<{string.Join(", ", TypeArguments.ConvertAll((arg) => arg.TypeName))}>")}";
-        public string Identifier => $"{IScopeSymbol.GetAbsolouteName(EnumDeclaration)}{(TypeArguments.Count == 0 ? string.Empty : $"_with_{string.Join("_", TypeArguments.ConvertAll((arg) => arg.TypeName))}")}";
+        public string Identifier => IType.GetIdentifier(IScopeSymbol.GetAbsolouteName(EnumDeclaration), TypeArguments.ToArray());
+        public string PrototypeIdentifier => IType.GetPrototypeIdentifier(IScopeSymbol.GetAbsolouteName(EnumDeclaration), EnumDeclaration.TypeParameters);
         public bool IsEmpty => false;
 
         public EnumDeclaration EnumDeclaration { get; private set; }

--- a/NoHoPython/IntermediateRepresentation/Statements/ForeignCDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/ForeignCDeclaration.cs
@@ -85,7 +85,7 @@ namespace NoHoPython.Typing
         private Lazy<Dictionary<string, ForeignCDeclaration.ForeignCProperty>> identifierPropertyMap;
         private Lazy<Dictionary<TypeParameter, IType>> typeargMap;
 
-        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
+        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement, Syntax.AstIRProgramBuilder irBuilder) => throw new NoDefaultValueError(this, errorReportedElement);
 
         public ForeignCType(ForeignCDeclaration declaration, List<IType> typeArguments, Syntax.IAstElement errorReportedElement) : this(declaration, TypeParameter.ValidateTypeArguments(declaration.TypeParameters, typeArguments, errorReportedElement))
         {

--- a/NoHoPython/IntermediateRepresentation/Statements/ForeignCDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/ForeignCDeclaration.cs
@@ -35,7 +35,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         public string? MarshallerDeclarations { get; private set; }
         public string CReferenceSource { get; private set; }
         public string? Copier { get; private set; }
-        public string? Mover { get; private set; }
         public string? Destructor { get; private set; }
         public string? ResponsibleDestroyerSetter { get; private set; }
 
@@ -44,7 +43,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 
         public List<ForeignCProperty>? Properties = null;
 
-        public ForeignCDeclaration(string name, List<TypeParameter> typeParameters, bool pointerPropertyAccess, string? forwardDeclaration, string? cStructDeclaration, string? marshallerHeaders, string? marshallerDeclarations, string cReferenceSource, string? copier, string? mover, string? destructor, string? responsibleDestroyerSetter, SymbolContainer parentContainer, Syntax.IAstElement errorReportedElement)
+        public ForeignCDeclaration(string name, List<TypeParameter> typeParameters, bool pointerPropertyAccess, string? forwardDeclaration, string? cStructDeclaration, string? marshallerHeaders, string? marshallerDeclarations, string cReferenceSource, string? copier, string? destructor, string? responsibleDestroyerSetter, SymbolContainer parentContainer, Syntax.IAstElement errorReportedElement)
         {
             Name = name;
             TypeParameters = typeParameters;
@@ -56,7 +55,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             MarshallerDeclarations = marshallerDeclarations;
             CReferenceSource = cReferenceSource;
             Copier = copier;
-            Mover = mover;
             Destructor = destructor;
             ResponsibleDestroyerSetter = responsibleDestroyerSetter;
 
@@ -154,7 +152,7 @@ namespace NoHoPython.Syntax.Statements
 
             List<Typing.TypeParameter> typeParameters = TypeParameters.ConvertAll((TypeParameter parameter) => parameter.ToIRTypeParameter(irBuilder, this));
 
-            IRDeclaration = new IntermediateRepresentation.Statements.ForeignCDeclaration(Identifier, typeParameters, Attributes.ContainsKey("ptr") || CSource.EndsWith('*'), GetOption("ForwardDeclaration"), GetOption("CStruct"), GetOption("MarshallerHeaders"), GetOption("Marshallers"), CSource, GetOption("Copy"), GetOption("Move"), GetOption("Destroy"), GetOption("ActorSetter"), irBuilder.SymbolMarshaller.CurrentModule, this);
+            IRDeclaration = new IntermediateRepresentation.Statements.ForeignCDeclaration(Identifier, typeParameters, Attributes.ContainsKey("ptr") || CSource.EndsWith('*'), GetOption("ForwardDeclaration"), GetOption("CStruct"), GetOption("MarshallerHeaders"), GetOption("Marshallers"), CSource, GetOption("Copy"), GetOption("Destroy"), GetOption("ActorSetter"), irBuilder.SymbolMarshaller.CurrentModule, this);
             irBuilder.SymbolMarshaller.DeclareSymbol(IRDeclaration, this);
             irBuilder.SymbolMarshaller.NavigateToScope(IRDeclaration);
 

--- a/NoHoPython/IntermediateRepresentation/Statements/ForeignCDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/ForeignCDeclaration.cs
@@ -75,7 +75,8 @@ namespace NoHoPython.Typing
     public sealed partial class ForeignCType : IType, IPropertyContainer
     {
         public string TypeName => $"{Declaration.Name}{(TypeArguments.Count == 0 ? string.Empty : $"<{string.Join(", ", TypeArguments.ConvertAll((arg) => arg.TypeName))}>")}";
-        public string Identifier => $"{IScopeSymbol.GetAbsolouteName(Declaration)}{(TypeArguments.Count == 0 ? string.Empty : $"_with_{string.Join("_", TypeArguments.ConvertAll((arg) => arg.TypeName))}")}";
+        public string Identifier => IType.GetIdentifier(IScopeSymbol.GetAbsolouteName(Declaration), TypeArguments.ToArray());
+        public string PrototypeIdentifier => IType.GetPrototypeIdentifier(IScopeSymbol.GetAbsolouteName(Declaration), Declaration.TypeParameters);
         public bool IsEmpty => false;
 
         public ForeignCDeclaration Declaration { get; private set; }

--- a/NoHoPython/IntermediateRepresentation/Statements/InterfaceDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/InterfaceDeclaration.cs
@@ -92,7 +92,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
                 throw new UnexpectedTypeException(value.Type, errorReportedElement);
         }
 
-        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => ArithmeticCast.CastTo(Value.SubstituteWithTypearg(typeargs), TargetType.SubstituteWithTypearg(typeargs));
+        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new MarshalIntoInterface((InterfaceType)TargetType.SubstituteWithTypearg(typeargs), Value.SubstituteWithTypearg(typeargs), ErrorReportedElement);
     }
 }
 
@@ -110,7 +110,7 @@ namespace NoHoPython.Typing
         private Lazy<List<InterfaceDeclaration.InterfaceProperty>> requiredImplementedProperties;
         private Lazy<Dictionary<string, InterfaceDeclaration.InterfaceProperty>> identifierPropertyMap;
 
-        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
+        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement, Syntax.AstIRProgramBuilder irBuilder) => throw new NoDefaultValueError(this, errorReportedElement);
 
         public InterfaceType(InterfaceDeclaration interfaceDeclaration, List<IType> typeArguments, Syntax.IAstElement errorReportedElement) : this(interfaceDeclaration, TypeParameter.ValidateTypeArguments(interfaceDeclaration.TypeParameters, typeArguments, errorReportedElement))
         {

--- a/NoHoPython/IntermediateRepresentation/Statements/InterfaceDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/InterfaceDeclaration.cs
@@ -101,7 +101,8 @@ namespace NoHoPython.Typing
     public sealed partial class InterfaceType : IType, IPropertyContainer
     {
         public string TypeName => $"{InterfaceDeclaration.Name}{(TypeArguments.Count == 0 ? string.Empty : $"<{string.Join(", ", TypeArguments.ConvertAll((arg) => arg.TypeName))}>")}";
-        public string Identifier => $"{IScopeSymbol.GetAbsolouteName(InterfaceDeclaration)}{(TypeArguments.Count == 0 ? string.Empty : $"_with_{string.Join("_", TypeArguments.ConvertAll((arg) => arg.TypeName))}")}";
+        public string Identifier => IType.GetIdentifier(IScopeSymbol.GetAbsolouteName(InterfaceDeclaration), TypeArguments.ToArray());
+        public string PrototypeIdentifier => IType.GetPrototypeIdentifier(IScopeSymbol.GetAbsolouteName(InterfaceDeclaration), InterfaceDeclaration.TypeParameters);
         public bool IsEmpty => false;
 
         public InterfaceDeclaration InterfaceDeclaration { get; private set; }

--- a/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
@@ -282,7 +282,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         public IAstElement ErrorReportedElement { get; private set; }
         public IRValue ToReturn { get; private set; }
 
-        private List<Variable> activeVariables;
         private ProcedureDeclaration parentProcedure;
 
         public ReturnStatement(IRValue toReturn, AstIRProgramBuilder irBuilder, IAstElement errorReportedStatement)
@@ -290,7 +289,6 @@ namespace NoHoPython.IntermediateRepresentation.Statements
 #pragma warning disable CS8604 // Return types may be linked in after initialization
             ToReturn = ArithmeticCast.CastTo(toReturn, irBuilder.ScopedProcedures.Peek().ReturnType);
 #pragma warning restore CS8604 
-            activeVariables = irBuilder.SymbolMarshaller.CurrentCodeBlock.GetCurrentLocals(irBuilder.ScopedProcedures.Peek());
             parentProcedure = irBuilder.ScopedProcedures.Peek();
             ErrorReportedElement = errorReportedStatement;
         }

--- a/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/Procedure.cs
@@ -423,6 +423,19 @@ namespace NoHoPython.IntermediateRepresentation.Values
             return new AnonymousProcedureCall(procedureValue, arguments, irBuilder, errorReportedElement);
         }
 
+        public static IRValue ComposeMessageReceiverCall(IRValue value, string receiverName, IType? expectedReturnType, List<IRValue> arguments, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement){
+            if(procedureValue is IPropertyContainer propertyContainer && propertyContainer.HasProperty(receiverName))
+                return ComposeCall(GetPropertyValue.ComposeGetProperty(propertyContainer, receiverName, irBuilder, errorReportedElement), arguments, irBuilder, errorReportedElement);
+            
+            IScopeSymbol? procedure = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.Identifier}_{name}");
+            if(procedure == null)
+                procedure = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.PrototypeIdentifier}_{name}");
+            
+            if(procedure != null)
+                return new LinkedProcedureCall(procedure, argments, expectedReturnType, irBuilder.ScopedProcedures.Count == 0 ? null : irBuilder.ScopedProcedures.Peek(), expectedReturnType, irBuilder, errorReportedElement);
+            throw new InvalidOperationException();
+        }
+
         public override IType Type => ProcedureType.ReturnType;
 
         public IRValue ProcedureValue { get; private set; }

--- a/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
@@ -18,7 +18,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
         }
     }
 
-    public partial interface IPropertyContainer
+    public interface IPropertyContainer
     {
         public static void SanitizePropertyNames(List<Property> properties, Syntax.IAstElement errorReportedElement)
         {

--- a/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
@@ -75,13 +75,13 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 return new(newName, Type.SubstituteWithTypearg(typeargs), IsReadOnly, (RecordType)RecordType.SubstituteWithTypearg(typeargs), RecordDeclaration);
             }
 
-            public void DelayedLinkSetDefaultValue(IRValue defaultValue)
+            public void DelayedLinkSetDefaultValue(IRValue defaultValue, Syntax.AstIRProgramBuilder irBuilder)
             {
                 Debug.Assert(!HasDefaultValue);
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
                 Debug.Assert(RecordDeclaration.properties.Contains(this));
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
-                RecordDeclaration.defaultValues[Name] = ArithmeticCast.CastTo(defaultValue, Type);
+                RecordDeclaration.defaultValues[Name] = ArithmeticCast.CastTo(defaultValue, Type, irBuilder);
             }
 
             public int CompareTo(RecordProperty? recordProperty) => Name.CompareTo(recordProperty?.Name);
@@ -197,7 +197,7 @@ namespace NoHoPython.Typing
         private Lazy<Dictionary<TypeParameter, IType>> typeargMap;
         private Lazy<List<IType>> constructorParameterTypes;
 
-        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
+        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement, Syntax.AstIRProgramBuilder irBuilder) => throw new NoDefaultValueError(this, errorReportedElement);
 
         public RecordType(RecordDeclaration recordPrototype, List<IType> typeArguments, Syntax.IAstElement errorReportedElement) : this(recordPrototype, TypeParameter.ValidateTypeArguments(recordPrototype.TypeParameters, typeArguments, errorReportedElement))
         {
@@ -314,7 +314,7 @@ namespace NoHoPython.Syntax.Statements
             {
                 var propertyValue = Properties[i].DefaultValue;
                 if (propertyValue != null)
-                    IRProperties[i].DelayedLinkSetDefaultValue(propertyValue.GenerateIntermediateRepresentationForValue(irBuilder, IRProperties[i].Type, false));
+                    IRProperties[i].DelayedLinkSetDefaultValue(propertyValue.GenerateIntermediateRepresentationForValue(irBuilder, IRProperties[i].Type, false), irBuilder);
             }
 
             IntermediateRepresentation.Statements.ProcedureDeclaration? Constructor = null;
@@ -328,7 +328,7 @@ namespace NoHoPython.Syntax.Statements
                 else if (reciever.Name == "__copy__")
                     Copier = (IntermediateRepresentation.Statements.ProcedureDeclaration)reciever.GenerateIntermediateRepresentationForStatement(irBuilder);
                 else
-                    messageRecieverPropertyMap[reciever].DelayedLinkSetDefaultValue(new AnonymizeProcedure((IntermediateRepresentation.Statements.ProcedureDeclaration)reciever.GenerateIntermediateRepresentationForStatement(irBuilder), false, reciever, null));
+                    messageRecieverPropertyMap[reciever].DelayedLinkSetDefaultValue(new AnonymizeProcedure((IntermediateRepresentation.Statements.ProcedureDeclaration)reciever.GenerateIntermediateRepresentationForStatement(irBuilder), false, reciever, null), irBuilder);
             });
 
             if (Constructor == null)

--- a/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/RecordDeclaration.cs
@@ -31,6 +31,18 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             }
         }
 
+        public static bool HasProperty(IType type, string name, Syntax.AstIRProgramBuilder irBuilder)
+        {
+            if (type is IPropertyContainer propertyContainer && propertyContainer.HasProperty(name))
+                return true;
+
+            IScopeSymbol? getter = irBuilder.SymbolMarshaller.FindSymbol($"{type.Identifier}_get_{name}");
+            if (getter == null)
+                getter = irBuilder.SymbolMarshaller.FindSymbol($"{type.PrototypeIdentifier}_get_{name}");
+
+            return getter is ProcedureDeclaration;
+        }
+
         public bool HasProperty(string identifier);
         public Property FindProperty(string identifier);
 
@@ -66,14 +78,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
                 DefaultValue = null;
             }
 
-            public RecordProperty SubstituteWithTypeargs(Dictionary<TypeParameter, IType> typeargs)
-            {
-                string newName = Name;
-                foreach (KeyValuePair<TypeParameter, IType> typearg in typeargs)
-                    newName = newName.Replace($"{typearg.Key.Name}_IDENT", typearg.Value.Identifier);
-
-                return new(newName, Type.SubstituteWithTypearg(typeargs), IsReadOnly, (RecordType)RecordType.SubstituteWithTypearg(typeargs), RecordDeclaration);
-            }
+            public RecordProperty SubstituteWithTypeargs(Dictionary<TypeParameter, IType> typeargs) => new(Name, Type.SubstituteWithTypearg(typeargs), IsReadOnly, (RecordType)RecordType.SubstituteWithTypearg(typeargs), RecordDeclaration);
 
             public void DelayedLinkSetDefaultValue(IRValue defaultValue, Syntax.AstIRProgramBuilder irBuilder)
             {
@@ -186,7 +191,9 @@ namespace NoHoPython.Typing
     {
         public bool IsNativeCType => false;
         public string TypeName => $"{RecordPrototype.Name}{(TypeArguments.Count == 0 ? string.Empty : $"<{string.Join(", ", TypeArguments.ConvertAll((arg) => arg.TypeName))}>")}";
-        public string Identifier => $"{IScopeSymbol.GetAbsolouteName(RecordPrototype)}{(TypeArguments.Count == 0 ? string.Empty : $"_with_{string.Join("_", TypeArguments.ConvertAll((arg) => arg.TypeName))}")}";
+        public string Identifier => IType.GetIdentifier(IScopeSymbol.GetAbsolouteName(RecordPrototype), TypeArguments.ToArray());
+        public string PrototypeIdentifier => IType.GetPrototypeIdentifier(IScopeSymbol.GetAbsolouteName(RecordPrototype), RecordPrototype.TypeParameters);
+
         public bool IsEmpty => false;
 
         public RecordDeclaration RecordPrototype;

--- a/NoHoPython/IntermediateRepresentation/Statements/TypedefDeclaration.cs
+++ b/NoHoPython/IntermediateRepresentation/Statements/TypedefDeclaration.cs
@@ -28,7 +28,7 @@ namespace NoHoPython.IntermediateRepresentation.Statements
             ErrorReportedElement = errorReportedElement;
         }
 
-        public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<Typing.TypeParameter, IType> typeargs, int indent) { }
+        public void Emit(IRProgram irProgram, Emitter emitter, Dictionary<Typing.TypeParameter, IType> typeargs) { }
 
         public void ScopeForUsedTypes(Dictionary<Typing.TypeParameter, IType> typeargs, AstIRProgramBuilder irBuilder) { }
 

--- a/NoHoPython/IntermediateRepresentation/Values/Arithmetic.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Arithmetic.cs
@@ -207,7 +207,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public ArithmeticOperation Operation { get; private set; }
         public override IType Type { get; }
 
-        private ArithmeticOperator(ArithmeticOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(left, right, false, errorReportedElement)
+        private ArithmeticOperator(ArithmeticOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(left, right, errorReportedElement)
         {
             Operation = operation;
 
@@ -243,7 +243,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public IRValue Address => Left;
         public IRValue Offset => Right;
 
-        public PointerAddOperator(IRValue address, IRValue offset, IAstElement errorReportedElement) : base(address, ArithmeticCast.CastTo(offset, Primitive.Integer), false, errorReportedElement)
+        public PointerAddOperator(IRValue address, IRValue offset, IAstElement errorReportedElement) : base(address, ArithmeticCast.CastTo(offset, Primitive.Integer), errorReportedElement)
         {
             if (address.Type is not HandleType)
                 throw new UnexpectedTypeException(address.Type, errorReportedElement);

--- a/NoHoPython/IntermediateRepresentation/Values/Arithmetic.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Arithmetic.cs
@@ -75,7 +75,9 @@ namespace NoHoPython.IntermediateRepresentation.Values
             {
                 if (explicitCast && value.Type is HandleType)
                     return new HandleCast(handleType, value, value.ErrorReportedElement);
-                else if (value.Type is MemorySpan || value.Type is ArrayType)
+                else if(value.Type is ArrayType)
+                    return new ArrayOperator(ArrayOperator.ArrayOperation.GetArrayHandle, value, value.ErrorReportedElement);
+                else if (value.Type is MemorySpan)
                     return new ArrayOperator(ArrayOperator.ArrayOperation.GetSpanHandle, value, value.ErrorReportedElement);
             }
             if (typeTarget is ArrayType && value.Type is MemorySpan)

--- a/NoHoPython/IntermediateRepresentation/Values/Arithmetic.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Arithmetic.cs
@@ -66,7 +66,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
             //infalible type conversions
             if (value.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty($"to_{typeTarget.Identifier}"))
             {
-                IRValue call = AnonymousProcedureCall.ComposeCall(new GetPropertyValue(value, $"to_{typeTarget.Identifier}", null, value.ErrorReportedElement), new List<IRValue>(), irBuilder, value.ErrorReportedElement);
+                IRValue call = AnonymousProcedureCall.ComposeCall(GetPropertyValue.ComposeGetProperty(value, $"to_{typeTarget.Identifier}", irBuilder, value.ErrorReportedElement), new List<IRValue>(), irBuilder, value.ErrorReportedElement);
                 if (!call.Type.IsCompatibleWith(typeTarget))
                     throw new UnexpectedTypeException(typeTarget, call.Type, value.ErrorReportedElement);
                 return call;
@@ -189,12 +189,12 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public static IRValue ComposeArithmeticOperation(ArithmeticOperation operation, IRValue left, IRValue right, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
         {
             return left.Type is IPropertyContainer leftContainer && leftContainer.HasProperty(operatorOverloadIdentifiers[operation])
-                ? AnonymousProcedureCall.ComposeCall(new GetPropertyValue(left, operatorOverloadIdentifiers[operation], null, errorReportedElement), new List<IRValue>()
+                ? AnonymousProcedureCall.ComposeCall(GetPropertyValue.ComposeGetProperty(left, operatorOverloadIdentifiers[operation], irBuilder, errorReportedElement), new List<IRValue>()
                 {
                     right
                 }, irBuilder, errorReportedElement)
                 : OperationIsCommunicative(operation) && right.Type is IPropertyContainer rightContainer && rightContainer.HasProperty(operatorOverloadIdentifiers[operation])
-                ? AnonymousProcedureCall.ComposeCall(new GetPropertyValue(right, operatorOverloadIdentifiers[operation], null, errorReportedElement), new List<IRValue>()
+                ? AnonymousProcedureCall.ComposeCall(GetPropertyValue.ComposeGetProperty(right, operatorOverloadIdentifiers[operation], irBuilder, errorReportedElement), new List<IRValue>()
                 {
                     left
                 }, irBuilder, errorReportedElement)

--- a/NoHoPython/IntermediateRepresentation/Values/Literals.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Literals.cs
@@ -87,7 +87,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public NullPointerLiteral(IType expectedType, IAstElement errorReportedElement)
         {
-            if (!(expectedType is HandleType || expectedType is ForeignCType foreignType && foreignType.Declaration.PointerPropertyAccess))
+            if (!(expectedType is HandleType || (expectedType is ForeignCType foreignType && foreignType.Declaration.PointerPropertyAccess)))
                 throw new UnexpectedTypeException(expectedType, errorReportedElement);
 
             Type = expectedType;

--- a/NoHoPython/IntermediateRepresentation/Values/Literals.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Literals.cs
@@ -189,18 +189,14 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public bool IsTruey => false;
         public bool IsFalsey => false;
 
-        public TupleType TupleType => new TupleType(TupleElements.ConvertAll((elem) => elem.Type));
+        public TupleType TupleType => new TupleType(Elements.ConvertAll((elem) => elem.Type));
 
-        public readonly List<IRValue> TupleElements;
+        public readonly List<IRValue> Elements;
 
         public TupleLiteral(List<IRValue> tupleElements, IAstElement errorReportedElement)
         {
-            TupleElements = tupleElements;
+            Elements = tupleElements;
             ErrorReportedElement = errorReportedElement;
-
-            //sort tuple elements
-            ITypeComparer comparer = new();
-            TupleElements.Sort((a, b) => comparer.Compare(a.Type, b.Type));
         }
     }
 
@@ -208,7 +204,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public IAstElement ErrorReportedElement { get; private set; }
 
-        public IType Type => TargetArrayChar ? new ArrayType(Primitive.Character) : Primitive.Handle;
+        public IType Type => TargetArrayChar ? new ArrayType(Primitive.Character) : Primitive.CString;
 
         public bool IsTruey => false;
         public bool IsFalsey => false;

--- a/NoHoPython/IntermediateRepresentation/Values/Operators.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Operators.cs
@@ -18,13 +18,10 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public IRValue Left { get; protected set; }
         public IRValue Right { get; protected set; }
 
-        public bool ShortCircuit { get; protected set; }
-
-        public BinaryOperator(IRValue left, IRValue right, bool shortCuircuit, IAstElement errorReportedElement)
+        public BinaryOperator(IRValue left, IRValue right, IAstElement errorReportedElement)
         {
             Left = left;
             Right = right;
-            ShortCircuit = shortCuircuit;
             ErrorReportedElement = errorReportedElement;
         }
     }
@@ -45,7 +42,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public CompareOperation Operation { get; private set; }
 
-        public ComparativeOperator(CompareOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(left, right, false, errorReportedElement)
+        public ComparativeOperator(CompareOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(left, right, errorReportedElement)
         {
             Operation = operation;
 
@@ -81,7 +78,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public LogicalOperation Operation { get; private set; }
 
-        public LogicalOperator(LogicalOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(ArithmeticCast.CastTo(left, Primitive.Boolean), ArithmeticCast.CastTo(right, Primitive.Boolean), true, errorReportedElement)
+        public LogicalOperator(LogicalOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(ArithmeticCast.CastTo(left, Primitive.Boolean), ArithmeticCast.CastTo(right, Primitive.Boolean), errorReportedElement)
         {
             Operation = operation;
         }
@@ -102,7 +99,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public BitwiseOperation Operation { get; private set; }
 
-        public BitwiseOperator(BitwiseOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(ArithmeticCast.CastTo(left, Primitive.Integer), ArithmeticCast.CastTo(right, Primitive.Integer), false, errorReportedElement)
+        public BitwiseOperator(BitwiseOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(ArithmeticCast.CastTo(left, Primitive.Integer), ArithmeticCast.CastTo(right, Primitive.Integer), errorReportedElement)
         {
             Operation = operation;
         }

--- a/NoHoPython/IntermediateRepresentation/Values/Operators.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Operators.cs
@@ -56,9 +56,9 @@ namespace NoHoPython.IntermediateRepresentation.Values
             }
             else
             {
-                if (left.Type is not Primitive)
+                if (left.Type is not Primitive && !(left.Type is ForeignCType foreignCType && foreignCType.Declaration.PointerPropertyAccess))
                     throw new UnexpectedTypeException(left.Type, left.ErrorReportedElement);
-                if (right.Type is not Primitive)
+                if (right.Type is not Primitive && !(right.Type is ForeignCType rightForeignCType && rightForeignCType.Declaration.PointerPropertyAccess))
                     throw new UnexpectedTypeException(right.Type, right.ErrorReportedElement);
             }
         }

--- a/NoHoPython/IntermediateRepresentation/Values/Operators.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Operators.cs
@@ -214,6 +214,18 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     public sealed partial class GetPropertyValue : IRValue
     {
+        public static bool HasMessageReceiver(IRValue value, string name, AstIRProgramBuilder irBuilder)
+        {
+            if(value.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty(name))
+                return true;
+            
+            IScopeSymbol? procedure = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.Identifier}_{name}");
+            if(procedure == null)
+                procedure = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.PrototypeIdentifier}_{name}");
+            
+            return procedure != null && procedure is ProcedureDeclaration;
+        }
+
         public static GetPropertyValue ComposeGetProperty(IRValue record, string propertyName, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement) => new GetPropertyValue(record, propertyName, record.GetRefinementEntry(irBuilder)?.GetSubentry(propertyName)?.Refinement, errorReportedElement);
 
         public IAstElement ErrorReportedElement { get; private set; }

--- a/NoHoPython/IntermediateRepresentation/Values/Operators.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Operators.cs
@@ -1,6 +1,7 @@
 using NoHoPython.IntermediateRepresentation;
 using NoHoPython.IntermediateRepresentation.Statements;
 using NoHoPython.IntermediateRepresentation.Values;
+using NoHoPython.Scoping;
 using NoHoPython.Syntax;
 using NoHoPython.Syntax.Parsing;
 using NoHoPython.Typing;
@@ -38,29 +39,57 @@ namespace NoHoPython.IntermediateRepresentation.Values
             LessEqual
         }
 
+        private static Dictionary<CompareOperation, CompareOperation> reversedCompareOperations = new Dictionary<CompareOperation, CompareOperation>() 
+        { 
+            {CompareOperation.Equals, CompareOperation.Equals},
+            {CompareOperation.NotEquals, CompareOperation.NotEquals},
+            {CompareOperation.Less, CompareOperation.More},
+            {CompareOperation.LessEqual, CompareOperation.MoreEqual},
+            {CompareOperation.More, CompareOperation.Less },
+            {CompareOperation.MoreEqual, CompareOperation.LessEqual}
+        };
+
+        public static IRValue ComposeComparativeOperator(CompareOperation operation, IRValue left, IRValue right, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
+        {
+            if (GetPropertyValue.HasMessageReceiver(left, "compare", irBuilder))
+                return new ComparativeOperator(operation, AnonymousProcedureCall.SendMessage(left, "compare", Primitive.Integer, new List<IRValue>()
+                    {
+                        right
+                    }, irBuilder, errorReportedElement), new IntegerLiteral(0, errorReportedElement), errorReportedElement);
+            if(GetPropertyValue.HasMessageReceiver(right, "compare", irBuilder))
+                return new ComparativeOperator(reversedCompareOperations[operation], AnonymousProcedureCall.SendMessage(right, "compare", Primitive.Integer, new List<IRValue>()
+                    {
+                        left
+                    }, irBuilder, errorReportedElement), new IntegerLiteral(0, errorReportedElement), errorReportedElement);
+            if (operation == CompareOperation.Equals || operation == CompareOperation.NotEquals)
+            {
+                if (GetPropertyValue.HasMessageReceiver(left, "equals", irBuilder))
+                    return AnonymousProcedureCall.SendMessage(left, "equals", Primitive.Boolean, new List<IRValue>()
+                    {
+                        right
+                    }, irBuilder, errorReportedElement);
+                if(GetPropertyValue.HasMessageReceiver(right, "equals", irBuilder))
+                    return AnonymousProcedureCall.SendMessage(right, "equals", Primitive.Boolean, new List<IRValue>()
+                    {
+                        left
+                    }, irBuilder, errorReportedElement);
+            }
+
+            return new ComparativeOperator(operation, left, right, irBuilder, errorReportedElement);
+        }
+
         public override IType Type => new BooleanType();
 
         public CompareOperation Operation { get; private set; }
 
-        public ComparativeOperator(CompareOperation operation, IRValue left, IRValue right, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement) : base(left, right, errorReportedElement)
+        private ComparativeOperator(CompareOperation operation, IRValue left, IRValue right, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement) : base(left, right, errorReportedElement)
         {
             Operation = operation;
 
-            if (left.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty("compare"))
-            {
-                Left = ArithmeticCast.CastTo(AnonymousProcedureCall.ComposeCall(GetPropertyValue.ComposeGetProperty(left, "compare", irBuilder, errorReportedElement), new List<IRValue>()
-                {
-                    right
-                }, irBuilder, errorReportedElement), Primitive.Integer, irBuilder);
-                Right = new IntegerLiteral(0, errorReportedElement);
-            }
-            else
-            {
-                if (left.Type is not Primitive && !(left.Type is ForeignCType foreignCType && foreignCType.Declaration.PointerPropertyAccess))
-                    throw new UnexpectedTypeException(left.Type, left.ErrorReportedElement);
-                if (right.Type is not Primitive && !(right.Type is ForeignCType rightForeignCType && rightForeignCType.Declaration.PointerPropertyAccess))
-                    throw new UnexpectedTypeException(right.Type, right.ErrorReportedElement);
-            }
+            if (left.Type is not Primitive && !(left.Type is ForeignCType foreignCType && foreignCType.Declaration.PointerPropertyAccess))
+                throw new UnexpectedTypeException(left.Type, left.ErrorReportedElement);
+            if (right.Type is not Primitive && !(right.Type is ForeignCType rightForeignCType && rightForeignCType.Declaration.PointerPropertyAccess))
+                throw new UnexpectedTypeException(right.Type, right.ErrorReportedElement);
         }
 
         private ComparativeOperator(CompareOperation operation, IRValue left, IRValue right, IAstElement errorReportedElement) : base(left, right, errorReportedElement)
@@ -124,11 +153,8 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public static IRValue ComposeGetValueAtIndex(IRValue array, IRValue index, IType? expectedType, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
         {
-            return array.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty("getAtIndex")
-                ? AnonymousProcedureCall.ComposeCall(GetPropertyValue.ComposeGetProperty(array, "getAtIndex", irBuilder, errorReportedElement), new List<IRValue>()
-                {
-                    index
-                }, irBuilder, array.ErrorReportedElement)
+            return GetPropertyValue.HasMessageReceiver(array, "getAtIndex", irBuilder)
+                ? AnonymousProcedureCall.SendMessage(array, "getAtIndex", expectedType, new List<IRValue>() { index }, irBuilder, errorReportedElement)
                 : array.Type is HandleType handleType
                 ? new MemoryGet(handleType.ValueType is not NothingType ? handleType.ValueType : expectedType ?? throw new UnexpectedTypeException(Primitive.Nothing, errorReportedElement), array, index, irBuilder, errorReportedElement)
                 : new GetValueAtIndex(array, index, irBuilder, errorReportedElement);
@@ -169,12 +195,8 @@ namespace NoHoPython.IntermediateRepresentation.Values
     {
         public static IRValue ComposeSetValueAtIndex(IRValue array, IRValue index, IRValue value, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
         {
-            return array.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty("setAtIndex")
-                ? AnonymousProcedureCall.ComposeCall(GetPropertyValue.ComposeGetProperty(array, "setAtIndex", irBuilder, errorReportedElement), new List<IRValue>()
-                {
-                    index,
-                    value
-                }, irBuilder, array.ErrorReportedElement)
+            return GetPropertyValue.HasMessageReceiver(array, "setAtIndex", irBuilder)
+                ? AnonymousProcedureCall.SendMessage(array, "setAtIndex", null, new List<IRValue>() { index, value}, irBuilder, errorReportedElement)
                 : array.Type is HandleType handleType
                 ? new MemorySet(handleType.ValueType is NothingType ? value.Type : handleType.ValueType, array, index, handleType.ValueType is NothingType ? value : ArithmeticCast.CastTo(value, handleType.ValueType, irBuilder), irBuilder, errorReportedElement)
                 : new SetValueAtIndex(array, index, value, irBuilder, errorReportedElement);
@@ -219,14 +241,23 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if(value.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty(name))
                 return true;
             
-            IScopeSymbol? procedure = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.Identifier}_{name}");
-            if(procedure == null)
-                procedure = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.PrototypeIdentifier}_{name}");
+            IScopeSymbol? messageReceiver = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.Identifier}_{name}");
+            if(messageReceiver == null)
+                messageReceiver = irBuilder.SymbolMarshaller.FindSymbol($"{value.Type.PrototypeIdentifier}_{name}");
             
-            return procedure != null && procedure is ProcedureDeclaration;
+            return messageReceiver != null && messageReceiver is ProcedureDeclaration;
         }
 
-        public static GetPropertyValue ComposeGetProperty(IRValue record, string propertyName, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement) => new GetPropertyValue(record, propertyName, record.GetRefinementEntry(irBuilder)?.GetSubentry(propertyName)?.Refinement, errorReportedElement);
+        public static IRValue ComposeGetProperty(IRValue record, string name, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
+        {
+            if (record.Type is IPropertyContainer propertyContainer && propertyContainer.HasProperty(name))
+                return new GetPropertyValue(record, name, record.GetRefinementEntry(irBuilder)?.GetSubentry(name)?.Refinement, errorReportedElement);
+
+            if (HasMessageReceiver(record, $"get_{name}", irBuilder))
+                return AnonymousProcedureCall.SendMessage(record, $"get_{name}", null, new(), irBuilder, errorReportedElement);
+
+            throw new UnexpectedTypeException(record.Type, $"Type doesn't contain property {name}.", errorReportedElement);
+        }
 
         public IAstElement ErrorReportedElement { get; private set; }
         public IType Type => Refinements.HasValue ? Refinements.Value.Item1 : Property.Type;
@@ -244,13 +275,29 @@ namespace NoHoPython.IntermediateRepresentation.Values
             Refinements = refinements;
             Property = record.Type is IPropertyContainer propertyContainer
 				? (propertyContainer.HasProperty(propertyName) ? propertyContainer.FindProperty(propertyName) : throw new UnexpectedTypeException(record.Type, $"Type doesn't contain property {propertyName}.", errorReportedElement))
-                : throw new UnexpectedTypeException(record.Type, errorReportedElement);
+                : throw new UnexpectedTypeException(record.Type, "Type isn't a property container.", errorReportedElement);
             ErrorReportedElement = errorReportedElement;
         }
     }
 
     public sealed partial class SetPropertyValue : IRValue, IRStatement
     {
+        public static IRValue ComposeSetPropertyValue(IRValue record, string name, IRValue value, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
+        {
+            if (record.Type is RecordType recordType && recordType.HasProperty(name))
+            {
+                CodeBlock.RefinementEntry? recordRefinement = record.GetRefinementEntry(irBuilder)?.GetSubentry(name);
+                recordRefinement?.Clear();
+                if (recordRefinement != null)
+                    value.RefineSet(irBuilder, recordRefinement);
+                return new SetPropertyValue(record, name, value, irBuilder, errorReportedElement);
+            }
+            if (GetPropertyValue.HasMessageReceiver(record, $"set_{name}", irBuilder))
+                AnonymousProcedureCall.SendMessage(record, $"set_{name}", null, new(), irBuilder, errorReportedElement);
+
+            throw new UnexpectedTypeException(record.Type, $"Type doesn't contain property {name}.", errorReportedElement);
+        }
+        
         public IAstElement ErrorReportedElement { get; private set; }
         public IType Type => Property.Type;
         public bool IsTruey => Value.IsTruey;
@@ -261,7 +308,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
         public IRValue Value { get; private set; }
 
-        public SetPropertyValue(IRValue record, string propertyName, IRValue value, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
+        private SetPropertyValue(IRValue record, string propertyName, IRValue value, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
         {
             Record = record;
             ErrorReportedElement = errorReportedElement;
@@ -270,13 +317,13 @@ namespace NoHoPython.IntermediateRepresentation.Values
             if (record.Type is RecordType propertyContainer)
             {
                 if (!propertyContainer.HasProperty(propertyName))
-                    throw new UnexpectedTypeException(record.Type, errorReportedElement);
+                    throw new UnexpectedTypeException(record.Type, $"Record doesn't contain property {propertyName}.", errorReportedElement);
 
                 Property = (RecordDeclaration.RecordProperty)propertyContainer.FindProperty(propertyName);
                 Value = ArithmeticCast.CastTo(value, Property.Type, irBuilder);
             }
             else
-                throw new UnexpectedTypeException(record.Type, errorReportedElement);
+                throw new UnexpectedTypeException(record.Type, $"Type isn't a record/class.", errorReportedElement);
         }
 
         private SetPropertyValue(IRValue record, RecordDeclaration.RecordProperty property, IRValue value, IAstElement errorReportedElement)
@@ -340,7 +387,7 @@ namespace NoHoPython.Syntax.Values
             return ArithmeticTokens.ContainsKey(Operator)
                 ? ArithmeticOperator.ComposeArithmeticOperation(ArithmeticTokens[Operator], lhs, Right.GenerateIntermediateRepresentationForValue(irBuilder, lhs.Type, willRevaluate), irBuilder, this)
                 : ComparativeTokens.ContainsKey(Operator)
-                ? new ComparativeOperator(ComparativeTokens[Operator], lhs, Right.GenerateIntermediateRepresentationForValue(irBuilder, lhs.Type, willRevaluate), irBuilder, this)
+                ? ComparativeOperator.ComposeComparativeOperator(ComparativeTokens[Operator], lhs, Right.GenerateIntermediateRepresentationForValue(irBuilder, lhs.Type, willRevaluate), irBuilder, this)
                 : LogicalTokens.ContainsKey(Operator)
                 ? new LogicalOperator(LogicalTokens[Operator], lhs, Right.GenerateIntermediateRepresentationForValue(irBuilder, Primitive.Boolean, willRevaluate), irBuilder, this)
                 : BitwiseTokens.ContainsKey(Operator)
@@ -366,20 +413,7 @@ namespace NoHoPython.Syntax.Values
 
     partial class GetPropertyValue
     {
-        public IRValue GenerateIntermediateRepresentationForValue(AstIRProgramBuilder irBuilder, IType? expectedType, bool willRevaluate)
-        {
-            IRValue record = Record.GenerateIntermediateRepresentationForValue(irBuilder, null, willRevaluate);
-
-            if (record.Type is IPropertyContainer property)
-            {
-                if (property.HasProperty($"get_{Property}"))
-                    return AnonymousProcedureCall.ComposeCall(IntermediateRepresentation.Values.GetPropertyValue.ComposeGetProperty(record, $"get_{Property}", irBuilder, this), new(), irBuilder, this);
-                else
-                    return IntermediateRepresentation.Values.GetPropertyValue.ComposeGetProperty(record, Property, irBuilder, this);
-            }
-            else
-                throw new UnexpectedTypeException(record.Type, "Expected a property container type.", record.ErrorReportedElement);
-        }
+        public IRValue GenerateIntermediateRepresentationForValue(AstIRProgramBuilder irBuilder, IType? expectedType, bool willRevaluate) => IntermediateRepresentation.Values.GetPropertyValue.ComposeGetProperty(Record.GenerateIntermediateRepresentationForValue(irBuilder, null, willRevaluate), Property, irBuilder, this);
     }
 
     partial class SetPropertyValue
@@ -393,29 +427,10 @@ namespace NoHoPython.Syntax.Values
         {
             IRValue record = Record.GenerateIntermediateRepresentationForValue(irBuilder, null, willRevaluate);
 
-            IType? hintType = expectedType;
-            if (record is IPropertyContainer propertyContainer && !propertyContainer.HasProperty(Property) && propertyContainer.HasProperty($"set_{Property}"))
-            {
-                IRValue getter = IntermediateRepresentation.Values.GetPropertyValue.ComposeGetProperty(record, $"set_property", irBuilder, this);
-                if (getter.Type is ProcedureType procedureType && procedureType.ParameterTypes.Count == 1)
-                    hintType = procedureType.ParameterTypes[0];
-                return AnonymousProcedureCall.ComposeCall(getter, new List<IRValue>()
-                {
-                    Value.GenerateIntermediateRepresentationForValue(irBuilder, hintType, willRevaluate)
-                }, irBuilder, this);
-            }
-            else
-            {
-                if (record.Type is RecordType recordType && recordType.HasProperty(Property))
-                    hintType = recordType.FindProperty(Property).Type;
-                IRValue value = Value.GenerateIntermediateRepresentationForValue(irBuilder, hintType, willRevaluate);
+            IType? hintType = record.Type is RecordType recordType && recordType.HasProperty(Property) ? recordType.FindProperty(Property).Type : expectedType;
+            IRValue value = Value.GenerateIntermediateRepresentationForValue(irBuilder, hintType, willRevaluate);
 
-                CodeBlock.RefinementEntry? recordRefinement = record.GetRefinementEntry(irBuilder)?.GetSubentry(Property);
-                recordRefinement?.Clear();
-                if (recordRefinement != null)
-                    value.RefineSet(irBuilder, recordRefinement);
-                return new IntermediateRepresentation.Values.SetPropertyValue(record, Property, value, irBuilder, this);
-            }
+            return IntermediateRepresentation.Values.SetPropertyValue.ComposeSetPropertyValue(record, Property, value, irBuilder, this);
         }
     }
 }

--- a/NoHoPython/IntermediateRepresentation/Values/Variable.cs
+++ b/NoHoPython/IntermediateRepresentation/Values/Variable.cs
@@ -113,11 +113,18 @@ namespace NoHoPython.IntermediateRepresentation.Values
         public Variable Variable { get; private set; }
         public IRValue SetValue { get; private set; }
 
-        public SetVariable(Variable variable, IRValue value, IAstElement errorReportedElement)
+        public SetVariable(Variable variable, IRValue value, AstIRProgramBuilder irBuilder, IAstElement errorReportedElement)
         {
             Variable = variable;
             ErrorReportedElement = errorReportedElement;
-            SetValue = ArithmeticCast.CastTo(value, Variable.Type);
+            SetValue = ArithmeticCast.CastTo(value, Variable.Type, irBuilder);
+        }
+
+        private SetVariable(Variable variable, IRValue setValue, IAstElement errorReportedElement)
+        {
+            ErrorReportedElement = errorReportedElement;
+            Variable = variable;
+            SetValue = setValue;
         }
 
         public IRValue SubstituteWithTypearg(Dictionary<Typing.TypeParameter, IType> typeargs) => throw new InvalidOperationException();
@@ -200,15 +207,15 @@ namespace NoHoPython.Syntax.Values
                     CodeBlock.RefinementEntry? refinementEntry = irBuilder.SymbolMarshaller.CurrentCodeBlock.GetRefinementEntry(variable, true);
                     refinementEntry?.Clear();
                     if(refinementEntry != null)
-                        setTo.RefineSetVariable(irBuilder, refinementEntry);
+                        setTo.RefineSet(irBuilder, refinementEntry);
                     else
                     {
                         CodeBlock.RefinementEntry newEntry = new(null, new());
-                        setTo.RefineSetVariable(irBuilder, newEntry);
+                        setTo.RefineSet(irBuilder, newEntry);
                         irBuilder.SymbolMarshaller.CurrentCodeBlock.NewRefinementEntry(variable, newEntry);
                     }
 
-                    return new IntermediateRepresentation.Values.SetVariable(variable, setTo, this);
+                    return new IntermediateRepresentation.Values.SetVariable(variable, setTo, irBuilder, this);
                 }
                 throw new NotAVariableException(valueSymbol, this);
             }

--- a/NoHoPython/NoHoPython.csproj
+++ b/NoHoPython/NoHoPython.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>Program</StartupObject>
+    <SignAssembly>False</SignAssembly>
+    <AssemblyName>nhp</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -54,7 +54,7 @@ public static class Program
             for (int i = 2; i < args.Length; i++)
                 flags.Add(args[i]);
             AstIRProgramBuilder astIRProgramBuilder = new(statements, flags);
-            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), !args.Contains("-nogcc"), args.Contains("-callstack") || args.Contains("-stacktrace"), args.Contains("-namert"), args.Contains("-linedir") || args.Contains("-ggdb"), args.Contains("-main"), memoryAnalyzer);
+            IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), args.Contains("-callstack") || args.Contains("-stacktrace"), args.Contains("-namert"), args.Contains("-linedir") || args.Contains("-ggdb"), args.Contains("-main"), memoryAnalyzer);
             sourceParser.IncludeCFiles(program);
 
             string outputFile;

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -25,6 +25,7 @@ public static class Program
         {
             DateTime compileStart = DateTime.Now;
 
+            Console.WriteLine("Parsing...");
             AstParser sourceParser = new AstParser(new Scanner(args[0], $"{Environment.CurrentDirectory}/stdlib"));
             List<IAstStatement> statements = sourceParser.ParseAll();
 
@@ -53,6 +54,8 @@ public static class Program
 
             for (int i = 2; i < args.Length; i++)
                 flags.Add(args[i]);
+
+            Console.WriteLine("Linking...");
             AstIRProgramBuilder astIRProgramBuilder = new(statements, flags);
             IRProgram program = astIRProgramBuilder.ToIRProgram(!args.Contains("-nobounds"), args.Contains("-noassert"), args.Contains("-callstack") || args.Contains("-stacktrace"), args.Contains("-namert"), args.Contains("-linedir") || args.Contains("-ggdb"), args.Contains("-main"), memoryAnalyzer);
             sourceParser.IncludeCFiles(program);
@@ -63,6 +66,7 @@ public static class Program
             else
                 outputFile = "out.c";
 
+            Console.WriteLine("Compiling...");
             if (args.Contains("-header"))
             {
                 string headerName = outputFile.EndsWith(".c") ? outputFile.Replace(".c", ".h") : outputFile + ".h";

--- a/NoHoPython/Program.cs
+++ b/NoHoPython/Program.cs
@@ -98,12 +98,12 @@ public static class Program
         {
             Console.WriteLine($"File not found: {f.Message}");
         }
-        catch (InvalidOperationException e)
-        {
-            Console.WriteLine("An internal compiler error has occured; please report the following stack trace to https://github.com/TheRealMichaelWang/NoHoPython/issues/new.");
-            Console.WriteLine(e.Message);
-            Console.WriteLine(e.StackTrace);
-        }
+        //catch (InvalidOperationException e)
+        //{
+        //    Console.WriteLine("An internal compiler error has occured; please report the following stack trace to https://github.com/TheRealMichaelWang/NoHoPython/issues/new.");
+        //    Console.WriteLine(e.Message);
+        //    Console.WriteLine(e.StackTrace);
+        //}
 
         return 0;
     }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/linked-list.nhp\r\nout.c"
+      "commandLineArgs": "tests/linked-list.nhp\r\nout.c\r\n-leaksan"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/map-test.nhp\r\nout.c\r\n-leaksan"
+      "commandLineArgs": "tests/bitwise-test.nhp\r\nout.c"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/interpolation-test.nhp\r\nout.c\r\n-leaksan"
+      "commandLineArgs": "tests/map-test.nhp\r\nout.c\r\n-leaksan"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/linked-list.nhp\r\nout.c\r\n-leaksan"
+      "commandLineArgs": "tests/interpolation-test.nhp\r\nout.c\r\n-leaksan"
     }
   }
 }

--- a/NoHoPython/Properties/launchSettings.json
+++ b/NoHoPython/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NoHoPython": {
       "commandName": "Project",
-      "commandLineArgs": "tests/bitwise-test.nhp\r\nout.c"
+      "commandLineArgs": "newfib.nhp\r\nout.c"
     }
   }
 }

--- a/NoHoPython/Scoping/SymbolMarshaller.cs
+++ b/NoHoPython/Scoping/SymbolMarshaller.cs
@@ -21,11 +21,11 @@ namespace NoHoPython.Scoping
             IsHeadContainer = isHeadContainer;
         }
 
-        public virtual IScopeSymbol? FindSymbol(string identifier, IAstElement errorReportedElement) => symbols.ContainsKey(identifier) ? symbols[identifier] : null;
+        public virtual IScopeSymbol? FindSymbol(string identifier) => symbols.ContainsKey(identifier) ? symbols[identifier] : null;
 
         public virtual void DeclareSymbol(IScopeSymbol symbol, IAstElement errorReportElement)
         {
-            IScopeSymbol? existingSymbol = FindSymbol(symbol.Name, errorReportElement);
+            IScopeSymbol? existingSymbol = FindSymbol(symbol.Name);
             if (existingSymbol == null)
             {
                 symbols.Add(symbol.Name, symbol);
@@ -97,7 +97,7 @@ namespace NoHoPython.Scoping
                 string[] parts = identifier.Split(':', StringSplitOptions.RemoveEmptyEntries);
                 for (int i = 0; i < parts.Length - 1; i++)
                 {
-                    IScopeSymbol? symbol = scopedContainer.FindSymbol(parts[i], errorReportedElement);
+                    IScopeSymbol? symbol = scopedContainer.FindSymbol(parts[i]);
                     if (symbol == null)
                         throw new SymbolNotFoundException(parts[i], scopedContainer, errorReportedElement);
                     else if (symbol is SymbolContainer symbolContainer)
@@ -115,7 +115,7 @@ namespace NoHoPython.Scoping
                 }
 
                 string finalIdentifier = parts.Last();
-                IScopeSymbol? result = scopedContainer.FindSymbol(finalIdentifier, errorReportedElement);
+                IScopeSymbol? result = scopedContainer.FindSymbol(finalIdentifier);
                 return result ?? throw new SymbolNotFoundException(finalIdentifier, scopedContainer, errorReportedElement);
             }
 
@@ -137,6 +137,48 @@ namespace NoHoPython.Scoping
                     }
             }
             throw new SymbolNotFoundException(identifier, scopeStack.Peek(), errorReportedElement);
+        }
+
+        public IScopeSymbol? FindSymbol(string identifier)
+        {
+            static IScopeSymbol? FindSymbolFromContainer(string identifier, SymbolContainer currentContainer, bool fromGlobalStack)
+            {
+                if (identifier.Contains(' '))
+                    throw new ArgumentException("Identifier cannot contain spaces.");
+
+                SymbolContainer scopedContainer = currentContainer;
+                string[] parts = identifier.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < parts.Length - 1; i++)
+                {
+                    IScopeSymbol? symbol = scopedContainer.FindSymbol(parts[i]);
+                    if (symbol == null)
+                        return null;
+                    else if (symbol is SymbolContainer symbolContainer)
+                    {
+                        if (fromGlobalStack && !symbolContainer.IsGloballyNavigable)
+                            return null;
+                        scopedContainer = symbolContainer;
+                    }
+                    else
+                        return null;
+                }
+
+                string finalIdentifier = parts.Last();
+                return scopedContainer.FindSymbol(finalIdentifier);
+            }
+
+            IScopeSymbol? result = FindSymbolFromContainer(identifier, scopeStack.Peek(), false);
+            if(result == null)
+            {
+                foreach(Module usedModule in usedModuleStack)
+                {
+                    result = FindSymbolFromContainer(identifier, usedModule, true);
+                    if (result != null)
+                        break;
+                }
+            }
+
+            return result;
         }
 
         public void DeclareSymbol(IScopeSymbol symbol, IAstElement errorReportedElement) => scopeStack.Peek().DeclareSymbol(symbol, errorReportedElement);

--- a/NoHoPython/Scoping/SymbolMarshaller.cs
+++ b/NoHoPython/Scoping/SymbolMarshaller.cs
@@ -62,7 +62,7 @@ namespace NoHoPython.Scoping
             public void DelayedLinkSetStatements(List<IRStatement> statements) => this.statements.AddRange(statements);
 
             public void ScopeForUsedTypes(Dictionary<Typing.TypeParameter, IType> typeargs, Syntax.AstIRProgramBuilder irBuilder) => throw new InvalidOperationException();
-            public void Emit(IRProgram irProgram, StatementEmitter emitter, Dictionary<Typing.TypeParameter, IType> typeargs, int indent) => throw new InvalidOperationException();
+            public void Emit(IRProgram irProgram, Emitter emitter, Dictionary<Typing.TypeParameter, IType> typeargs) => throw new InvalidOperationException();
             public bool AllCodePathsReturn() => throw new InvalidOperationException();
 
             public void AnalyzePropertyInitialization(SortedSet<RecordDeclaration.RecordProperty> initializedProperties, RecordDeclaration recordDeclaration) => throw new InvalidOperationException();

--- a/NoHoPython/Syntax/Ast.cs
+++ b/NoHoPython/Syntax/Ast.cs
@@ -6,7 +6,7 @@ namespace NoHoPython.Syntax
 {
     public interface IAstElement : ISourceLocatable
     { 
-        public void EmitSrcAsCString(IEmitter emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
+        public void EmitSrcAsCString(Emitter emitter, bool formatStr=true, bool encapsulateWithQuotes=true)
         {
             if (this is IAstValue astValue)
                 CharacterLiteral.EmitCString(emitter, astValue.ToString(), formatStr, encapsulateWithQuotes);
@@ -57,7 +57,7 @@ namespace NoHoPython.Syntax
 
         public override string ToString() => $"File \"{File}\", row {Row}, col {Column}";
 
-        public void EmitLineDirective(IEmitter emitter)
+        public void EmitLineDirective(Emitter emitter)
         {
             emitter.Append($"#line {Row} ");
 

--- a/NoHoPython/Syntax/Parsing/Parser.cs
+++ b/NoHoPython/Syntax/Parsing/Parser.cs
@@ -181,7 +181,11 @@ namespace NoHoPython.Syntax.Parsing
                 if (matchTok == null)
                 {
                     MatchAndScanToken(TokenType.Newline);
-                    lastCountedIndents = CountIndent();
+                    int countedIndents = CountIndent();
+                    if (scanner.LastToken.Type == TokenType.Newline)
+                        return false;
+
+                    lastCountedIndents = countedIndents;
                     if (lastCountedIndents != currentExpectedIndents)
                         throw new IndentationLevelException(currentExpectedIndents, lastCountedIndents, scanner.CurrentLocation);
                     return true;
@@ -191,7 +195,11 @@ namespace NoHoPython.Syntax.Parsing
                     if (scanner.LastToken.Type == TokenType.EndOfFile)
                         return false;
                     MatchAndScanToken(TokenType.Newline);
-                    lastCountedIndents = CountIndent();
+                    int countedIndents = CountIndent();
+                    if (scanner.LastToken.Type == TokenType.Newline)
+                        return false;
+
+                    lastCountedIndents = countedIndents;
 
                     if (lastCountedIndents < currentExpectedIndents || scanner.LastToken.Type != matchTok)
                     {

--- a/NoHoPython/Syntax/Typing.cs
+++ b/NoHoPython/Syntax/Typing.cs
@@ -148,7 +148,7 @@ namespace NoHoPython.Syntax.Values
         public IRValue GenerateIntermediateRepresentationForValue(AstIRProgramBuilder irBuilder, IType? expectedType, bool willRevaluate) 
         {
             IType targetType = TargetType.ToIRType(irBuilder, this);
-            return ArithmeticCast.CastTo(ToCast.GenerateIntermediateRepresentationForValue(irBuilder, targetType, willRevaluate), targetType, true);
+            return ArithmeticCast.CastTo(ToCast.GenerateIntermediateRepresentationForValue(irBuilder, targetType, willRevaluate), targetType, irBuilder, true);
         }
     }
 }

--- a/NoHoPython/Syntax/Values/Literals.cs
+++ b/NoHoPython/Syntax/Values/Literals.cs
@@ -62,12 +62,14 @@ namespace NoHoPython.Syntax.Values
 
         public override string ToString()
         {
-            BufferedEmitter emitter = new(String.Length);
-            emitter.Append('\"');
-            foreach (char c in String)
-                IntermediateRepresentation.Values.CharacterLiteral.EmitCChar(emitter, c, false);
-            emitter.Append('\"');
-            return emitter.ToString();
+            using(Emitter emitter = new())
+            {
+                emitter.Append('\"');
+                foreach (char c in String)
+                    IntermediateRepresentation.Values.CharacterLiteral.EmitCChar(emitter, c, false);
+                emitter.Append('\"');
+                return emitter.GetBuffered();
+            }
         }
     }
 

--- a/NoHoPython/Typing/BasicTypes.cs
+++ b/NoHoPython/Typing/BasicTypes.cs
@@ -1,6 +1,7 @@
 ﻿using NoHoPython.IntermediateRepresentation;
 using NoHoPython.IntermediateRepresentation.Values;
 using NoHoPython.Syntax;
+using System.Text;
 
 namespace NoHoPython.Typing
 {
@@ -24,6 +25,7 @@ namespace NoHoPython.Typing
 
         public abstract string TypeName { get; }
         public string Identifier => TypeName;
+        public string PrototypeIdentifier => Identifier;
         public bool IsEmpty => false;
 
         public abstract int Id { get; }
@@ -118,6 +120,7 @@ namespace NoHoPython.Typing
     {
         public string TypeName => "nothing";
         public string Identifier => "nothing";
+        public string PrototypeIdentifier => "nothing";
         public bool IsEmpty => true;
 
         public IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new EmptyTypeLiteral(Primitive.Nothing, errorReportedElement);
@@ -131,6 +134,7 @@ namespace NoHoPython.Typing
     {
         public string TypeName => $"array<{ElementType.TypeName}>";
         public string Identifier => $"array_{ElementType.Identifier}";
+        public string PrototypeIdentifier => $"array_T";
         public bool IsEmpty => false;
 
         public IType ElementType { get; private set; }
@@ -149,6 +153,7 @@ namespace NoHoPython.Typing
     {
         public string TypeName => $"span<{ElementType.TypeName}, {Length}>";
         public string Identifier => $"span_{ElementType.Identifier}_of_{Length}";
+        public string PrototypeIdentifier => $"span_T_of_{Length}";
         public bool IsEmpty => false;
 
         public IType ElementType { get; private set; }
@@ -168,7 +173,29 @@ namespace NoHoPython.Typing
     public sealed partial class ProcedureType : IType
     {
         public string TypeName => $"fn<{ReturnType.TypeName}, {string.Join(", ", ParameterTypes.ConvertAll((type) => type.TypeName))}>";
-        public string Identifier => $"proc_{string.Join(string.Empty, ParameterTypes.ConvertAll((type) => $"{type.Identifier}_"))}ret_{ReturnType.Identifier}";
+        public string Identifier
+        {
+            get
+            {
+                List<IType> typeargs = new(ParameterTypes);
+                typeargs.Insert(0, ReturnType);
+                return IType.GetIdentifier("fn", typeargs.ToArray());
+            }
+        
+        }
+        public string PrototypeIdentifier
+        {
+            get
+            {
+                StringBuilder builder = new();
+                builder.Append("fn_");
+                builder.Append(ReturnType is NothingType ? "None" : "RT");
+                for (int i = 0; i < ParameterTypes.Count; i++)
+                    builder.Append("_T");
+                return builder.ToString();
+            }
+        }
+
         public bool IsEmpty => false;
 
         public IType ReturnType { get; private set; }

--- a/NoHoPython/Typing/BasicTypes.cs
+++ b/NoHoPython/Typing/BasicTypes.cs
@@ -28,7 +28,7 @@ namespace NoHoPython.Typing
 
         public abstract int Id { get; }
 
-        public abstract IRValue GetDefaultValue(IAstElement errorReportedElement);
+        public abstract IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder);
 
         public abstract bool IsCompatibleWith(IType type);
         public abstract IType SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeArgs);
@@ -39,7 +39,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(this, errorReportedElement);
         }
 
-        public virtual IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument) => ArithmeticCast.CastTo(argument, this);
+        public virtual IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder) => ArithmeticCast.CastTo(argument, this, irBuilder);
 
         public override string ToString() => TypeName;
         public override int GetHashCode() => Id;
@@ -50,7 +50,7 @@ namespace NoHoPython.Typing
         public override string TypeName => "int";
         public override int Id => 0;
 
-        public override IRValue GetDefaultValue(IAstElement errorReportedElement) => new IntegerLiteral(0, errorReportedElement);
+        public override IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new IntegerLiteral(0, errorReportedElement);
 
         public override bool IsCompatibleWith(IType type)
         {
@@ -63,7 +63,7 @@ namespace NoHoPython.Typing
         public override string TypeName => "dec";
         public override int Id => 1;
 
-        public override IRValue GetDefaultValue(IAstElement errorReportedElement) => new DecimalLiteral(0, errorReportedElement);
+        public override IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new DecimalLiteral(0, errorReportedElement);
 
         public override bool IsCompatibleWith(IType type)
         {
@@ -76,7 +76,7 @@ namespace NoHoPython.Typing
         public override string TypeName { get => "char"; }
         public override int Id => 2;
 
-        public override IRValue GetDefaultValue(IAstElement errorReportedElement) => new CharacterLiteral('\0', errorReportedElement);
+        public override IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new CharacterLiteral('\0', errorReportedElement);
 
         public override bool IsCompatibleWith(IType type)
         {
@@ -89,7 +89,7 @@ namespace NoHoPython.Typing
         public override string TypeName => "bool";
         public override int Id => 3;
 
-        public override IRValue GetDefaultValue(IAstElement errorReportedElement) => new FalseLiteral(errorReportedElement);
+        public override IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new FalseLiteral(errorReportedElement);
 
         public override bool IsCompatibleWith(IType type)
         {
@@ -102,7 +102,7 @@ namespace NoHoPython.Typing
         public override string TypeName => $"handle<{ValueType.TypeName}>";
         public override int Id => 4;
 
-        public override IRValue GetDefaultValue(IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
+        public override IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => throw new NoDefaultValueError(this, errorReportedElement);
 
         public IType ValueType { get; private set; }
 
@@ -120,7 +120,7 @@ namespace NoHoPython.Typing
         public string Identifier => "nothing";
         public bool IsEmpty => true;
 
-        public IRValue GetDefaultValue(IAstElement errorReportedElement) => new EmptyTypeLiteral(Primitive.Nothing, errorReportedElement);
+        public IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new EmptyTypeLiteral(Primitive.Nothing, errorReportedElement);
 
         public bool IsCompatibleWith(IType type) => type is NothingType;
 
@@ -135,7 +135,7 @@ namespace NoHoPython.Typing
 
         public IType ElementType { get; private set; }
 
-        public IRValue GetDefaultValue(IAstElement errorReportedElement) => new ArrayLiteral(ElementType, new(), errorReportedElement);
+        public IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new ArrayLiteral(ElementType, new(), irBuilder, errorReportedElement);
 
         public ArrayType(IType elementType)
         {
@@ -154,7 +154,7 @@ namespace NoHoPython.Typing
         public IType ElementType { get; private set; }
         public int Length { get; private set; }
 
-        public IRValue GetDefaultValue(IAstElement errorReportedElement) => new ArrayLiteral(ElementType, new(), errorReportedElement);
+        public IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new ArrayLiteral(ElementType, new(), irBuilder, errorReportedElement);
 
         public MemorySpan(IType elementType, int length)
         {
@@ -174,7 +174,7 @@ namespace NoHoPython.Typing
         public IType ReturnType { get; private set; }
         public readonly List<IType> ParameterTypes;
 
-        public IRValue GetDefaultValue(IAstElement errorReportedElement) => throw new NoDefaultValueError(this, errorReportedElement);
+        public IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => throw new NoDefaultValueError(this, errorReportedElement);
 
         public ProcedureType(IType returnType, List<IType> parameterTypes)
         {

--- a/NoHoPython/Typing/TupleType.cs
+++ b/NoHoPython/Typing/TupleType.cs
@@ -3,6 +3,7 @@ using NoHoPython.IntermediateRepresentation.Statements;
 using NoHoPython.IntermediateRepresentation.Values;
 using NoHoPython.Syntax;
 using NoHoPython.Typing;
+using System.Text;
 
 namespace NoHoPython.Typing
 {
@@ -19,7 +20,18 @@ namespace NoHoPython.Typing
         }
 
         public string TypeName => $"tuple<{string.Join(", ", orderedValueTypes.ConvertAll((type) => type.TypeName))}>";
-        public string Identifier => $"tuple_{string.Join("_", orderedValueTypes.ConvertAll((type) => type.Identifier))}";
+        public string Identifier => IType.GetIdentifier("tuple", orderedValueTypes.ToArray());
+        public string PrototypeIdentifier
+        {
+            get
+            {
+                StringBuilder builder = new();
+                builder.Append("tuple");
+                for (int i = 0; i < orderedValueTypes.Count; i++)
+                    builder.Append("_T");
+                return builder.ToString();
+            }
+        }
         public bool IsEmpty => false;
 
         public readonly Dictionary<IType, int> ValueTypes;

--- a/NoHoPython/Typing/TupleType.cs
+++ b/NoHoPython/Typing/TupleType.cs
@@ -26,7 +26,7 @@ namespace NoHoPython.Typing
         private readonly List<IType> orderedValueTypes;
         private readonly Dictionary<string, Property> properties; 
 
-        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement) => new TupleLiteral(orderedValueTypes.ConvertAll((type) => type.GetDefaultValue(errorReportedElement)), errorReportedElement);
+        public IRValue GetDefaultValue(IAstElement errorReportedElement, AstIRProgramBuilder irBuilder) => new TupleLiteral(orderedValueTypes.ConvertAll((type) => type.GetDefaultValue(errorReportedElement, irBuilder)), errorReportedElement);
 
         public TupleType(List<IType> valueTypes)
         {

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -1,11 +1,36 @@
 ﻿using NoHoPython.IntermediateRepresentation;
 using NoHoPython.IntermediateRepresentation.Statements;
 using NoHoPython.Scoping;
+using System.Text;
 
 namespace NoHoPython.Typing
 {
     public partial interface IType
     {
+        public static string GetIdentifier(string typeIdentifier, params IType[] typeargs)
+        {
+            StringBuilder builder = new();
+            builder.Append(typeIdentifier);
+            foreach(IType type in typeargs)
+            {
+                builder.Append('_');
+                builder.Append(type.Identifier);
+            }
+            return builder.ToString();
+        }
+
+        public static string GetPrototypeIdentifier(string typeIdentifier, List<TypeParameter> typeParameters)
+        {
+            StringBuilder builder = new();
+            builder.Append(typeIdentifier);
+            foreach (TypeParameter typeParameter in typeParameters)
+            {
+                builder.Append('_');
+                builder.Append(typeParameter.Name);
+            }
+            return builder.ToString();
+        }
+
         public bool IsNativeCType { get; }
         public bool RequiresDisposal { get; }
         public bool MustSetResponsibleDestroyer { get; }

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -20,13 +20,12 @@ namespace NoHoPython.Typing
         public string GetCName(IRProgram irProgram);
         public string GetStandardIdentifier(IRProgram irProgram);
 
-        public void EmitFreeValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string childAgent);
-        public void EmitCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitMoveValue(IRProgram irProgram, IEmitter emitter, string destC, string valueCSource, string childAgent);
-        public void EmitClosureBorrowValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string responsibleDestroyer);
-        public void EmitRecordCopyValue(IRProgram irProgram, IEmitter emitter, string valueCSource, string newRecordCSource);
+        public void EmitFreeValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valuePromise, Emitter.Promise childAgent);
+        public void EmitCopyValue(IRProgram irProgram, Emitter primaryEmitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer);
+        public void EmitClosureBorrowValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise responsibleDestroyer);
+        public void EmitRecordCopyValue(IRProgram irProgram, Emitter emitter, Emitter.Promise valueCSource, Emitter.Promise newRecord);
 
-        public void EmitCStruct(IRProgram irProgram, StatementEmitter emitter);
+        public void EmitCStruct(IRProgram irProgram, Emitter emitter);
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder);
 

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -29,12 +29,12 @@ namespace NoHoPython.Typing
 
         public void ScopeForUsedTypes(Syntax.AstIRProgramBuilder irBuilder);
 
-        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement);
+        public IRValue GetDefaultValue(Syntax.IAstElement errorReportedElement, Syntax.AstIRProgramBuilder irBuilder);
 
         public bool IsCompatibleWith(IType type);
         public IType SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs);
         public void MatchTypeArgumentWithType(Dictionary<TypeParameter, IType> typeargs, IType argument, Syntax.IAstElement errorReportedElement);
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument);
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder);
 
         public string? ToString() => TypeName;
     }

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -74,6 +74,12 @@ namespace NoHoPython.Typing
             ExpectedType = null;
             RecievedType = recievedType;
         }
+
+        public UnexpectedTypeException(IType recievedType, string comments, Syntax.IAstElement errorReportedElement) : base(errorReportedElement, $"Unexpected type {recievedType.TypeName} recieved. {comments}")
+        {
+            ExpectedType = null;
+            RecievedType = recievedType;
+        }
     }
 
     public sealed class UnexpectedTypeArgumentsException : IRGenerationError

--- a/NoHoPython/Typing/Type.cs
+++ b/NoHoPython/Typing/Type.cs
@@ -13,6 +13,7 @@ namespace NoHoPython.Typing
 
         public string TypeName { get; }
         public string Identifier { get; }
+        public string PrototypeIdentifier {get;}
         public bool IsEmpty { get; }
 
         public bool TypeParameterAffectsCodegen(Dictionary<IType, bool> effectInformation);

--- a/NoHoPython/Typing/TypeParameter.cs
+++ b/NoHoPython/Typing/TypeParameter.cs
@@ -124,16 +124,16 @@ namespace NoHoPython.Typing
             }
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (typeargs.ContainsKey(TypeParameter))
             {
-                return typeargs[TypeParameter].IsCompatibleWith(argument.Type) ? argument : ArithmeticCast.CastTo(argument, typeargs[TypeParameter]);
+                return typeargs[TypeParameter].IsCompatibleWith(argument.Type) ? argument : ArithmeticCast.CastTo(argument, typeargs[TypeParameter], irBuilder);
             }
             else
             {
 #pragma warning disable CS8604 //not actually possible because supports type always returns true if null
-                IRValue newArgument = TypeParameter.SupportsType(argument.Type) ? argument : ArithmeticCast.CastTo(argument, TypeParameter.RequiredImplementedInterface);
+                IRValue newArgument = TypeParameter.SupportsType(argument.Type) ? argument : ArithmeticCast.CastTo(argument, TypeParameter.RequiredImplementedInterface, irBuilder);
 #pragma warning restore CS8604 
                 typeargs.Add(TypeParameter, newArgument.Type);
                 return newArgument;
@@ -153,7 +153,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public override IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public override IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is HandleType handleType)
             {
@@ -161,7 +161,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs)));
+                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs), irBuilder), irBuilder);
         }
     }
 
@@ -177,7 +177,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is ArrayType arrayType)
             {
@@ -185,7 +185,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs)));
+                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs), irBuilder), irBuilder);
         }
     }
 
@@ -201,7 +201,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is MemorySpan memorySpan)
             {
@@ -209,7 +209,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs)));
+                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs), irBuilder), irBuilder);
         }
     }
 
@@ -243,7 +243,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(this, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument) => ArithmeticCast.CastTo(argument, this);
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder) => ArithmeticCast.CastTo(argument, this, irBuilder);
     }
 
     partial class EmptyEnumOption
@@ -256,7 +256,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument) => ArithmeticCast.CastTo(argument, this);
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder) => ArithmeticCast.CastTo(argument, this, irBuilder);
     }
 
     partial class EnumType
@@ -271,7 +271,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is EnumType enumType && EnumDeclaration == enumType.EnumDeclaration)
             {
@@ -279,7 +279,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs)));
+                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs), irBuilder), irBuilder);
         }
     }
 
@@ -295,7 +295,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is RecordType recordType && RecordPrototype == recordType.RecordPrototype)
             {
@@ -303,7 +303,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs)));
+                return MatchTypeArgumentWithValue(typeargs, ArithmeticCast.CastTo(argument, SubstituteWithTypearg(typeargs), irBuilder), irBuilder);
         }
     }
 
@@ -319,7 +319,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is InterfaceType interfaceType && InterfaceDeclaration == interfaceType.InterfaceDeclaration)
             {
@@ -327,7 +327,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return ArithmeticCast.CastTo(argument, this);
+                return ArithmeticCast.CastTo(argument, this, irBuilder);
         }
     }
 
@@ -343,7 +343,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is ForeignCType foreignCType && Declaration == foreignCType.Declaration)
             {
@@ -351,7 +351,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return ArithmeticCast.CastTo(argument, this);
+                return ArithmeticCast.CastTo(argument, this, irBuilder);
         }
     }
 
@@ -370,7 +370,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is ProcedureType procedureType)
             {
@@ -379,7 +379,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return ArithmeticCast.CastTo(argument, this);
+                return ArithmeticCast.CastTo(argument, this, irBuilder);
         }
     }
 
@@ -395,7 +395,7 @@ namespace NoHoPython.Typing
                 throw new UnexpectedTypeException(argument, errorReportedElement);
         }
 
-        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument)
+        public IRValue MatchTypeArgumentWithValue(Dictionary<TypeParameter, IType> typeargs, IRValue argument, Syntax.AstIRProgramBuilder irBuilder)
         {
             if (argument.Type is TupleType tupleType)
             {
@@ -403,7 +403,7 @@ namespace NoHoPython.Typing
                 return argument;
             }
             else
-                return ArithmeticCast.CastTo(argument, this);
+                return ArithmeticCast.CastTo(argument, this, irBuilder);
         }
     }
 }
@@ -502,7 +502,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class ArithmeticOperator
     {
-        public override IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new ArithmeticOperator(Operation, Left.SubstituteWithTypearg(typeargs), Right.SubstituteWithTypearg(typeargs), ErrorReportedElement);
+        public override IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new ArithmeticOperator(Type.SubstituteWithTypearg(typeargs), Operation, Left.SubstituteWithTypearg(typeargs), Right.SubstituteWithTypearg(typeargs), ErrorReportedElement);
     }
 
     partial class PointerAddOperator
@@ -562,7 +562,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class GetValueAtIndex
     {
-        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new GetValueAtIndex(Array.SubstituteWithTypearg(typeargs), Index.SubstituteWithTypearg(typeargs), ErrorReportedElement);
+        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new GetValueAtIndex(Type.SubstituteWithTypearg(typeargs), Array.SubstituteWithTypearg(typeargs), Index.SubstituteWithTypearg(typeargs), ErrorReportedElement);
     }
 
     partial class SetValueAtIndex
@@ -581,6 +581,6 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class SetPropertyValue
     {
-        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new SetPropertyValue(Record.SubstituteWithTypearg(typeargs), Property.Name, Value.SubstituteWithTypearg(typeargs), ErrorReportedElement);
+        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new SetPropertyValue(Record.SubstituteWithTypearg(typeargs), Property.SubstituteWithTypeargs(typeargs), Value.SubstituteWithTypearg(typeargs), ErrorReportedElement);
     }
 }

--- a/NoHoPython/Typing/TypeParameter.cs
+++ b/NoHoPython/Typing/TypeParameter.cs
@@ -79,6 +79,7 @@ namespace NoHoPython.Typing
 
         public string TypeName => TypeParameter.Name;
         public string Identifier => TypeName;
+        public string PrototypeIdentifier => Identifier;
         public bool IsEmpty => false;
 
         public TypeParameter TypeParameter { get; private set; }

--- a/NoHoPython/Typing/TypeParameter.cs
+++ b/NoHoPython/Typing/TypeParameter.cs
@@ -457,7 +457,7 @@ namespace NoHoPython.IntermediateRepresentation.Values
 
     partial class TupleLiteral
     {
-        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new TupleLiteral(TupleElements.Select((IRValue element) => element.SubstituteWithTypearg(typeargs)).ToList(), ErrorReportedElement);
+        public IRValue SubstituteWithTypearg(Dictionary<TypeParameter, IType> typeargs) => new TupleLiteral(Elements.Select((IRValue element) => element.SubstituteWithTypearg(typeargs)).ToList(), ErrorReportedElement);
     }
 
     partial class MarshalIntoLowerTuple

--- a/NoHoPython/stdlib/io.nhp
+++ b/NoHoPython/stdlib/io.nhp
@@ -2,8 +2,9 @@ include "shared.nhp"
 include "stream.nhp"
 
 mod std:
+	cdef ioptr "FILE*"
+
 	mod io:
-		cdef ioptr "FILE*"
 
 		class handleOutputStream:
 			ioptr ptr
@@ -12,7 +13,7 @@ mod std:
 				self.ptr = ptr
 			
 			def writeByte(char byte):
-				cdef fputc(char, handle) None
+				cdef fputc(char, ioptr) None
 				fputc(byte, self.ptr)
 
 			def writeBuffer(array<char> buffer) int:
@@ -72,24 +73,24 @@ mod std:
 			def peek() char:
 				return self.input.peek()
 
-		def openFile(string path, string mode) shared<handle>:
+		def openFile(string path, string mode) shared<ioptr>:
 			cdef fopen(handle<char>, handle<char>) ioptr
 			cdef fclose(ioptr) None
 
 			ptr = fopen(path.cstr, mode.cstr)
 			assert ptr != NULL
 
-			return makeShared(ptr, lambda handle toFree: fclose(toFree))
+			return makeShared(ptr, lambda ioptr toFree: fclose(toFree))
 
 def input() string:
-	cdef stdin ioptr
+	cdef stdin std::ioptr
 
 	inStream = new std::io::handleInputStream(stdin)
 	buf = std::stream::readLine(inStream)
 	return std::makeString(buf)
 
 def print(string msg) None:
-	cdef stdout ioptr
+	cdef stdout std::ioptr
 
 	outStream = new std::io::handleOutputStream(stdout)
 	for i from 0 within msg.length:

--- a/NoHoPython/stdlib/io.nhp
+++ b/NoHoPython/stdlib/io.nhp
@@ -5,7 +5,6 @@ mod std:
 	cdef ioptr "FILE*"
 
 	mod io:
-
 		class handleOutputStream:
 			ioptr ptr
 		
@@ -73,14 +72,23 @@ mod std:
 			def peek() char:
 				return self.input.peek()
 
-		def openFile(string path, string mode) shared<ioptr>:
+		def openFileUnsafe(string path, handle<char> mode) shared<ioptr>:
 			cdef fopen(handle<char>, handle<char>) ioptr
 			cdef fclose(ioptr) None
 
-			ptr = fopen(path.cstr, mode.cstr)
+			ptr = fopen(path.cstr, mode)
 			assert ptr != NULL
 
 			return makeShared(ptr, lambda ioptr toFree: fclose(toFree))
+
+		def openFile(string path, handle<char> mode) option<shared<ioptr>>:
+			cdef fopen(handle<char>, handle<char>) ioptr
+			cdef fclose(ioptr) None
+
+			ptr = fopen(path.cstr, mode)
+			if ptr == NULL:
+				return None
+			return makeShared(ptr, lambda ioptr toFree: fclose(toFree)) as shared<ioptr>
 
 def input() string:
 	cdef stdin std::ioptr

--- a/NoHoPython/stdlib/list.nhp
+++ b/NoHoPython/stdlib/list.nhp
@@ -1,5 +1,5 @@
 mod data:
-	def convertList<T, X>(list<T> input, fn<X, T> convert) list<X>:
+	def list_T_convertList<T, X>(list<T> input, fn<X, T> convert) list<X>:
 		converted = new list<X>(input.count)
 		for i from 0 within input.count:
 			converted.pushBack(convert(input[i]))
@@ -106,7 +106,7 @@ mod data:
 			destroy self.buffer + self.count
 			return popped
 		
-		def to_array_T_IDENT() array<T>:
+		def to_array_T() array<T>:
 			return marshal T[self.count](self.buffer)
 		
 		def forall(fn<None, T> todo):

--- a/NoHoPython/stdlib/map.nhp
+++ b/NoHoPython/stdlib/map.nhp
@@ -23,10 +23,6 @@ mod data:
 			self.keyBuckets = std::malloc(bucketCount) as handle<int>
 			self.valueBuckets = std::malloc(bucketCount) as handle<V>
 			self.bucketStates = std::calloc(bucketCount) as handle<bool>
-			
-			assert self.keyBuckets != None
-			assert self.valueBuckets != None
-			assert self.bucketStates != None
 
 		def __copy__() hashmap<K, V>:
 			copied = new hashmap<K, V>(self.hasher, self.bucketCount)
@@ -42,8 +38,7 @@ mod data:
 				if self.bucketStates[i] as bool:
 					destroy self.valueBuckets + i
 
-			cstd::
-			self.keyBuckets)
+			cstd::free(self.keyBuckets)
 			cstd::free(self.valueBuckets)
 			cstd::free(self.bucketStates)
 		
@@ -83,9 +78,6 @@ mod data:
 				self.keyBuckets = std::malloc(self.bucketCount) as handle<int>
 				self.valueBuckets = std::malloc(self.bucketCount) as handle<V>
 				self.bucketStates = std::calloc(self.bucketCount) as handle<bool>
-				assert self.keyBuckets != None
-				assert self.valueBuckets != None
-				assert self.bucketStates != None
 
 				for i from 0 within oldBucketCount:
 					if oldBucketStates[i] as bool:

--- a/NoHoPython/stdlib/map.nhp
+++ b/NoHoPython/stdlib/map.nhp
@@ -42,7 +42,8 @@ mod data:
 				if self.bucketStates[i] as bool:
 					destroy self.valueBuckets + i
 
-			cstd::free(self.keyBuckets)
+			cstd::
+			self.keyBuckets)
 			cstd::free(self.valueBuckets)
 			cstd::free(self.bucketStates)
 		

--- a/NoHoPython/stdlib/shared.nhp
+++ b/NoHoPython/stdlib/shared.nhp
@@ -23,7 +23,7 @@
 				
 	def makeShared<T>(T resource, fn<None, T> destructor) shared<T>:
 		counterPtr = std::malloc(1) as handle<int>
-		assert counterPtr != None
+		assert counterPtr != NULL
 		counterPtr[0] = 0
 		
 		return new shared<T>(resource, counterPtr, destructor)

--- a/NoHoPython/tests/bare-hello-world.nhp
+++ b/NoHoPython/tests/bare-hello-world.nhp
@@ -1,5 +1,5 @@
 ﻿#this is a barebones implementation of hello world
 
 def main():
-	cdef puts(handle) None
+	cdef puts(handle<char>) None
 	puts("Hello World!")

--- a/NoHoPython/tests/bitwise-test.nhp
+++ b/NoHoPython/tests/bitwise-test.nhp
@@ -1,12 +1,15 @@
 ﻿include "io.nhp"
+include "textstream.nhp"
 
 def main():
-	outWriter = std::io::handleOutputStream(stdout)
+	cdef stdout std::ioptr
 
-	outWriter.writeLine("give a number...")
+	writer = new std::textWriter(new std::io::handleOutputStream(stdout))
+
+	writer.writeLine("give a number...")
 	N = input() as int
 
 	for i from 0 to 1 lshift N:
 		for j from 0 within N:
-			out.writeByte('*' if i & (1 lshift j) else ' ')
-		out.writeByte('\n')
+			writer.output.writeByte('*' if i & (1 lshift j) else ' ')
+		writer.output.writeByte('\n')

--- a/NoHoPython/tests/linked-list.nhp
+++ b/NoHoPython/tests/linked-list.nhp
@@ -1,7 +1,5 @@
 ﻿include "mem.nhp"
 
-#linked lists no longer work because of restrictions on match statements; matched variables are copies of the original enum values. See issue #18 for more details
-
 enum nullable<T>:
 	T
 	None
@@ -64,7 +62,7 @@ def main():
 		
 		stop = myList.isEmpty
 		while stop() == False:
-			match res=myList.popFront():
+			match myList.popFront():
 				int j:
 					printf("%i\n\0", j)
 				None:

--- a/NoHoPython/tests/linked-list.nhp
+++ b/NoHoPython/tests/linked-list.nhp
@@ -18,7 +18,7 @@ class list<T>:
 	def __init__():
 		self.head = None
 	
-	def isEmpty() bool:
+	def get_isEmpty() bool:
 		match self.head:
 			node<T>:
 				return False
@@ -60,8 +60,7 @@ def main():
 			myList.pushBack(i)
 		mem::report()
 		
-		stop = myList.isEmpty
-		while stop() == False:
+		while myList.isEmpty == False:
 			match myList.popFront():
 				int j:
 					printf("%i\n\0", j)


### PR DESCRIPTION
- Added overloading to sending messages to objects
  - If we had an object `myType myObject` and wanted to say invoke `myObject.call()`, we don't need to implement call as a physical property that occupies memory. Instead implementing a procedure `myType_call(myType myObject)` would be good enough.
- Added getters and setters
- Enhanced operator overloading